### PR TITLE
fix: make conditional auth header expansion zsh-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,6 @@ VM_METRICS_URL        # VictoriaMetrics query endpoint (e.g., http://localhost:8
 VM_LOGS_URL           # VictoriaLogs endpoint (e.g., http://localhost:9428)
 VM_TRACES_URL         # VictoriaTraces with /select/jaeger prefix (e.g., http://localhost:10428/select/jaeger)
 VM_ALERTMANAGER_URL   # AlertManager endpoint (optional)
-VM_AUTH_HEADER        # Auth header value (empty for local, set for prod)
+VM_AUTH_HEADER        # Full HTTP header line, e.g. "Authorization: Bearer <token>"
+                      # (empty for local, set for prod)
 ```

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/alertmanager-check.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/alertmanager-check.md
@@ -13,7 +13,7 @@ You are a signal-gathering subagent. Your role is to check the current alert sta
 All curl commands use conditional auth — when `VM_AUTH_HEADER` is empty the `-H` flag is omitted automatically:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_METRICS_URL/..."
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_METRICS_URL/..."
 ```
 
 ## Task
@@ -23,7 +23,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_METRICS_URL/..."
 Query the VictoriaMetrics alerts endpoint. This is always reachable and is the primary source of firing/pending alert state:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/alerts" | jq '.data.alerts[]'
 ```
 
@@ -35,7 +35,7 @@ AlertManager is an in-cluster pod. Test connectivity first with a 5-second timeo
 
 ```bash
 curl -sf -o /dev/null -w "%{http_code}" --max-time 5 \
-  ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+  ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts"
 ```
 
@@ -43,11 +43,11 @@ curl -sf -o /dev/null -w "%{http_code}" --max-time 5 \
 
 ```bash
 # Active alerts (not silenced, not inhibited)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?active=true&silenced=false&inhibited=false" | jq .
 
 # Active silences
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" \
   | jq '[.[] | select(.status.state == "active")]'
 ```

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
@@ -21,7 +21,7 @@ You are the **Logs Discovery Agent**. Your role is to discover and query Victori
 All curl commands use conditional auth — when `VM_AUTH_HEADER` is empty, the `-H` flag is omitted automatically:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_LOGS_URL/select/logsql/..."
 ```
 
@@ -48,7 +48,7 @@ Run these steps in order. Substitute `<RFC3339>` with the investigation start ti
 Discover which stream fields exist (e.g., `namespace`, `pod`, `container`, `app`). Stream fields are indexed and fast to filter on.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_names?start=<RFC3339>" | jq .
 ```
@@ -58,7 +58,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 Discover what namespace values exist. This confirms the correct namespace identifier before filtering.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_values?start=<RFC3339>&field=namespace" | jq .
 ```
@@ -70,7 +70,7 @@ If the target uses a different stream field for namespacing (e.g., `kubernetes.p
 Facets return value distributions for ALL fields in a single call. Use a namespace filter to scope to the target.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="<NAMESPACE>"}' \
   "$VM_LOGS_URL/select/logsql/facets?start=<RFC3339>&end=<RFC3339>" | jq .
 ```
@@ -82,7 +82,7 @@ This reveals log levels, pod names, container names, and any other structured fi
 Discover non-indexed fields present in log messages (e.g., `level`, `error`, `trace_id`, `request_id`).
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="<NAMESPACE>"}' \
   "$VM_LOGS_URL/select/logsql/field_names?start=<RFC3339>" | jq .
 ```
@@ -92,7 +92,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 Query for error-level log entries to establish what errors exist and what they look like.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="<NAMESPACE>"} (error OR warn OR fatal OR exception) -"vm_slow_query_stats"' \
   "$VM_LOGS_URL/select/logsql/query?start=<RFC3339>&end=<RFC3339>&limit=20" \
   | jq -s '.[] | {time: ._time, level: .level, msg: ._msg}'
@@ -133,7 +133,7 @@ LogsQL is space-separated (AND by default). Pipes use `|`.
 Use `stats_query` with `time`. The query MUST contain a `| stats` pipe.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="<NAMESPACE>"} | stats by (level) count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query?time=<RFC3339>" | jq .
 ```
@@ -143,7 +143,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 Use `stats_query_range` with `start`, `end`, and `step`. The query MUST contain a `| stats` pipe.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="<NAMESPACE>"} error | stats count() as errors' \
   "$VM_LOGS_URL/select/logsql/stats_query_range?start=<RFC3339>&end=<RFC3339>&step=1h" | jq .
 ```

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
@@ -13,7 +13,7 @@ You are the **Logs Discovery Agent**. Your role is to discover and query Victori
 #   Prod:  export VM_LOGS_URL="https://vlselect.example.com"
 #   Local: export VM_LOGS_URL="http://localhost:9428"
 #
-# $VM_AUTH_HEADER - auth header (set for prod, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty for local)
 #   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
 #   Local: export VM_AUTH_HEADER=""
 ```

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/metrics-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/metrics-discovery.md
@@ -12,7 +12,7 @@ You are a Metrics Discovery Agent. Your role is to discover and query VictoriaMe
 Auth pattern — works for both authenticated and unauthenticated environments:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_METRICS_URL/..."
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_METRICS_URL/..."
 ```
 
 When `VM_AUTH_HEADER` is empty, the `-H` flag is omitted automatically.
@@ -26,7 +26,7 @@ Execute these steps in order. Do not skip steps.
 Search for metrics related to the target service or component using a keyword. Run multiple keyword searches if the service or problem domain has multiple relevant terms (e.g., `http_request`, `memory`, `pod`).
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/metadata?metric=<keyword>&limit=10" | jq .
 ```
 
@@ -39,7 +39,7 @@ Verify the target namespace exists and list pods within it.
 **Verify namespace exists:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="<target>"}' \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 ```
@@ -49,7 +49,7 @@ If the target namespace is not in the returned list, stop and report the availab
 **List pods in the namespace:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="<target>"}' \
   "$VM_METRICS_URL/api/v1/label/pod/values" | jq '.data[]'
 ```
@@ -57,7 +57,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 **List other relevant labels** (e.g., `container`, `job`, `service`) as needed:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="<target>"}' \
   "$VM_METRICS_URL/api/v1/label/container/values" | jq '.data[]'
 ```
@@ -67,7 +67,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 Discover all metric names actively present for the target namespace.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="<target>"}' \
   "$VM_METRICS_URL/api/v1/series?limit=20" | jq '[.data[] | .__name__] | unique | sort'
 ```
@@ -75,7 +75,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 If the target has a specific label (e.g., `service`, `job`, or `container`), scope further:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="<target>", container="<service>"}' \
   "$VM_METRICS_URL/api/v1/series?limit=20" | jq '[.data[] | .__name__] | unique | sort'
 ```
@@ -85,7 +85,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 Run an instant query to verify a discovered metric returns data and to capture a representative sample value.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=<metric_name>{namespace="<target>"}' \
   "$VM_METRICS_URL/api/v1/query" | jq '.data.result[] | {metric: .metric, value: .value[1]}'
 ```
@@ -97,7 +97,7 @@ Run this for 1–3 key metrics relevant to the investigation scope.
 Run a range query to capture trends over the relevant time window. Use RFC3339 timestamps.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=<metric_name>{namespace="<target>"}' \
   -d 'start=<RFC3339_start>' \
   -d 'end=<RFC3339_end>' \

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/metrics-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/metrics-discovery.md
@@ -6,7 +6,9 @@ You are a Metrics Discovery Agent. Your role is to discover and query VictoriaMe
 
 ```bash
 # $VM_METRICS_URL - VictoriaMetrics base URL
-# $VM_AUTH_HEADER - auth header (set for authenticated environments, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for authenticated environments, empty for local)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 Auth pattern — works for both authenticated and unauthenticated environments:

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/traces-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/traces-discovery.md
@@ -18,7 +18,7 @@ You are the Traces Discovery Agent. Your role is to discover and query VictoriaT
 Conditional auth pattern — omits `-H` automatically when `VM_AUTH_HEADER` is empty:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services" | jq .
 ```
 
@@ -53,7 +53,7 @@ Run these in order. Always start with services — you must know the service nam
 ### Step 1: List All Services
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services" | jq '.data[]'
 ```
 
@@ -63,7 +63,7 @@ No parameters. Returns all traced service names. Always start here.
 
 ```bash
 # <service> is a PATH parameter — substitute the actual service name
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services/<service>/operations" | jq '.data[]'
 ```
 
@@ -73,7 +73,7 @@ Run for the target service identified in Step 1.
 
 ```bash
 # endTs uses MILLISECONDS (13 digits), lookback uses MILLISECONDS
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/dependencies?endTs=$(date +%s%3N)&lookback=3600000" | jq '.data[]'
 ```
 
@@ -85,19 +85,19 @@ Returns edges between services showing call relationships. Adjust `lookback` for
 
 ```bash
 # Basic search — last 1 hour, limit 20 (times in MICROSECONDS, 16 digits)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=<service>&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=20" | jq .
 
 # With operation filter
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=<service>&operation=<operation>&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=20" | jq .
 
 # With minimum duration (string format: "1s", "500ms")
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=<service>&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&minDuration=1s&limit=20" | jq .
 
 # With maximum duration
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=<service>&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&maxDuration=500ms&limit=20" | jq .
 ```
 
@@ -106,7 +106,7 @@ Optional parameters: `operation`, `minDuration` (string, e.g. `"1s"`), `maxDurat
 ### Step 5: Get Trace by ID
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces/<traceID>" | jq .
 ```
 

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/traces-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/traces-discovery.md
@@ -10,7 +10,9 @@ You are the Traces Discovery Agent. Your role is to discover and query VictoriaT
 # $VM_TRACES_URL - base URL already including /select/jaeger prefix
 #   Prod:  export VM_TRACES_URL="https://vtselect.example.com/select/jaeger"
 #   Local: export VM_TRACES_URL="http://localhost:10428/select/jaeger"
-# $VM_AUTH_HEADER - auth header (set for prod, empty string for local/no-auth)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty string for local/no-auth)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 **IMPORTANT: `$VM_TRACES_URL` already includes `/select/jaeger`. Do NOT add `/select/jaeger` again. All endpoints below use `$VM_TRACES_URL/api/...`.**

--- a/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
+++ b/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
@@ -50,7 +50,7 @@ TSDB status queries and as series selectors to label queries.
 **Query 1 — Yesterday's series (captures recently churned series):**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb?topN=50&date=$(date -d 'yesterday' +%Y-%m-%d)" | jq '.data'
 ```
 
@@ -59,7 +59,7 @@ Queries yesterday's stats — broader than today (includes series that may have 
 **Query 2 — Today's active series:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb?topN=50" | jq '.data'
 ```
 
@@ -68,7 +68,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 ```bash
 for label in pod instance container path url user_id request_id session_id trace_id le name; do
   echo "=== focusLabel=$label ===" && \
-  curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+  curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
     "$VM_METRICS_URL/api/v1/status/tsdb?topN=20&focusLabel=$label" | \
     jq --arg l "$label" '{label: $l, focus: .data.seriesCountByFocusLabelValue}'
 done
@@ -86,21 +86,21 @@ done
 **Query 1 — Never-queried metrics:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?le=0&limit=500" | jq '.'
 ```
 
 **Query 2 — Rarely-queried metrics (≤5 total queries):**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?le=5&limit=500" | jq '.'
 ```
 
 **Query 3 — Stats overview (tracking period):**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=1" | \
   jq '{statsCollectedSince: .statsCollectedSince, statsCollectedRecordsTotal: .statsCollectedRecordsTotal}'
 ```
@@ -111,7 +111,7 @@ Note this in the return and proceed — the analysis can still work with TSDB st
 **Query 4 — Cross-check: are "unused" metrics referenced in alerting rules?**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/rules" | jq '[.data.groups[].rules[].query]'
 ```
 
@@ -135,7 +135,7 @@ All data comes from the TSDB status endpoint — do NOT use `/api/v1/labels` or 
 **Query 1 — Label cardinality overview (unique value counts + series counts):**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb?topN=50" | \
   jq '{labelValueCountByLabelName: .data.labelValueCountByLabelName, seriesCountByLabelName: .data.seriesCountByLabelName}'
 ```
@@ -149,7 +149,7 @@ For each label with >100 unique values from Query 1, fetch sample values:
 ```bash
 for label in <top labels from Query 1>; do
   echo "=== focusLabel=$label ===" && \
-  curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+  curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
     "$VM_METRICS_URL/api/v1/status/tsdb?topN=20&focusLabel=$label" | \
     jq --arg l "$label" '{label: $l, topValues: .data.seriesCountByFocusLabelValue}'
 done
@@ -160,7 +160,7 @@ done
 **Query 3 — High-cardinality label-value pairs:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb?topN=50" | \
   jq '.data.seriesCountByLabelValuePair'
 ```

--- a/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
+++ b/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
@@ -28,7 +28,9 @@ Uses the same env vars as the `victoriametrics-query` skill:
 # $VM_METRICS_URL - base URL
 #   cluster: export VM_METRICS_URL="https://vmselect.example.com/select/0/prometheus"
 #   single: export VM_METRICS_URL="http://localhost:8428"
-# $VM_AUTH_HEADER - auth header (empty if no auth is required)
+# $VM_AUTH_HEADER - full HTTP header line (empty if no auth is required)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 ## Workflow

--- a/plugins/diagnostics/skills/victoriametrics-unused-metrics-analysis/SKILL.md
+++ b/plugins/diagnostics/skills/victoriametrics-unused-metrics-analysis/SKILL.md
@@ -43,7 +43,7 @@ Phase 3: Report findings and suggest fixes
 Before doing anything, check that the metric names stats tracker is returning data. The feature is enabled by default since v1.113.0, but may have been disabled or the instance may be too old.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=3" | jq .
 ```
 
@@ -75,7 +75,7 @@ These are metrics with `queryRequests: 0` — tracked but never fetched by any q
 Use a high limit to capture all of them — the default 1000 is often not enough:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?le=0&limit=50000" | jq .
 ```
 
@@ -97,7 +97,7 @@ The goal is to find metrics that ARE being actively ingested but NOT being queri
 
 # CORRECT — counts only the specific never-queried metric names:
 # Build a regex from the actual never-queried names in that prefix group
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=count({__name__=~"container_blkio_device_usage_total|container_file_descriptors|container_last_seen|container_memory_failcnt|container_sockets|container_tasks_state"})' \
   "$VM_METRICS_URL/api/v1/query" | jq '.data.result[0].value[1]'
 ```
@@ -119,7 +119,7 @@ Do NOT spend time individually querying hundreds of historical metrics with 0 se
 These are metrics queried only a handful of times — possibly from one-off exploration rather than active use.
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?le=5&limit=50000" | jq .
 ```
 
@@ -131,11 +131,11 @@ This gives context for what percentage of metrics are unused and how much impact
 
 ```bash
 # Total tracked metric names
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=1" | jq '.statsCollectedRecordsTotal'
 
 # Total active time series
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=count({__name__=~".+"})' \
   "$VM_METRICS_URL/api/v1/query" | jq '.data.result[0].value[1]'
 ```

--- a/plugins/diagnostics/skills/victoriametrics-unused-metrics-analysis/SKILL.md
+++ b/plugins/diagnostics/skills/victoriametrics-unused-metrics-analysis/SKILL.md
@@ -23,7 +23,9 @@ Uses the same env vars as the `victoriametrics-query` skill:
 # $VM_METRICS_URL - base URL
 #   cluster: export VM_METRICS_URL="https://vmselect.example.com/select/0/prometheus"
 #   single: export VM_METRICS_URL="http://localhost:8428"
-# $VM_AUTH_HEADER - auth header (empty if no auth is required)
+# $VM_AUTH_HEADER - full HTTP header line (empty if no auth is required)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 ## How It Works

--- a/plugins/query/skills/alertmanager-query/SKILL.md
+++ b/plugins/query/skills/alertmanager-query/SKILL.md
@@ -17,7 +17,7 @@ AlertManager runs as an in-cluster pod and may be unavailable (crashloop, DNS fa
 
 ```bash
 # Fallback: firing/pending alerts from VictoriaMetrics (always available)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/alerts" | jq '.data.alerts[]'
 ```
 
@@ -37,7 +37,7 @@ AlertManager provides what VM alerts cannot: silences, inhibition state, and ale
 All curl commands use conditional auth:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
 ```
 
 When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
@@ -48,20 +48,20 @@ When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
 
 ```bash
 # All alerts (active, silenced, inhibited)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
 
 # Only active (not silenced, not inhibited)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?active=true&silenced=false&inhibited=false" | jq .
 
 # Filter by label matcher (URL-encode the matcher)
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'filter=alertname="HighMemory"' \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
 
 # Filter by receiver
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?receiver=slack-critical" | jq .
 ```
 
@@ -71,11 +71,11 @@ Parameters: `active` (bool, default true), `silenced` (bool, default true), `inh
 
 ```bash
 # All silences
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq .
 
 # Filter silences by matcher
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'filter=alertname="HighMemory"' \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq .
 ```
@@ -86,7 +86,7 @@ Parameters: `filter` (string array, matcher expressions)
 
 ```bash
 # Note: singular "silence" in path (not "silences")
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silence/{silenceID}" | jq .
 ```
 
@@ -95,7 +95,7 @@ Replace `{silenceID}` with the UUID.
 ### Create Silence
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "matchers": [
@@ -115,7 +115,7 @@ Returns `{"silenceID": "uuid-here"}`. Matcher fields: `name` (label name), `valu
 
 ```bash
 # Note: singular "silence" in path
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X DELETE \
   "$VM_ALERTMANAGER_URL/api/v2/silence/{silenceID}"
 ```
@@ -146,15 +146,15 @@ All timestamps use RFC3339 format: `2026-03-07T00:00:00Z`
 
 ```bash
 # Quick connectivity check
-curl -sf -o /dev/null -w "%{http_code}" ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -sf -o /dev/null -w "%{http_code}" ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" && echo " OK" || echo " UNREACHABLE"
 
 # Count firing alerts
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?active=true&silenced=false&inhibited=false" | jq 'length'
 
 # Silence an alert for 2 hours from now
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X POST -H "Content-Type: application/json" \
   -d "$(jq -n --arg start "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg end "$(date -u -d '+2 hours' +%Y-%m-%dT%H:%M:%SZ)" \
@@ -164,7 +164,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq .
 
 # Check if a specific alert is silenced
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'filter=alertname="TargetAlert"' \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?active=false&silenced=true" | jq 'length'
 ```

--- a/plugins/query/skills/alertmanager-query/SKILL.md
+++ b/plugins/query/skills/alertmanager-query/SKILL.md
@@ -29,7 +29,9 @@ AlertManager provides what VM alerts cannot: silences, inhibition state, and ale
 # $VM_ALERTMANAGER_URL - base URL
 #   Prod: export VM_ALERTMANAGER_URL="https://alertmanager.example.com"
 #   Local: N/A (AlertManager typically not deployed locally)
-# $VM_AUTH_HEADER - auth header (set for prod, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty for local)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 ## Auth Pattern

--- a/plugins/query/skills/alertmanager-query/references/api-reference.md
+++ b/plugins/query/skills/alertmanager-query/references/api-reference.md
@@ -68,16 +68,16 @@ List alerts with optional filters.
 
 ```bash
 # All active, non-silenced alerts
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts?active=true&silenced=false&inhibited=false" | jq .
 
 # Filter by label
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'filter=severity="critical"' \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
 
 # Multiple filters
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'filter=alertname="HighMemory"' \
   --data-urlencode 'filter=namespace="production"' \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" | jq .
@@ -147,11 +147,11 @@ List all silences.
 
 ```bash
 # All silences
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq .
 
 # Active silences only
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq '[.[] | select(.status.state == "active")]'
 ```
 
@@ -207,7 +207,7 @@ Create a new silence.
 
 ```bash
 # Create a 2-hour silence for a specific alert
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "matchers": [{"name": "alertname", "value": "HighMemory", "isRegex": false, "isEqual": true}],
@@ -219,7 +219,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silences" | jq .
 
 # Regex silence — silence all alerts matching pattern
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X POST -H "Content-Type: application/json" \
   -d '{
     "matchers": [{"name": "alertname", "value": "High.*", "isRegex": true, "isEqual": true}],
@@ -246,7 +246,7 @@ Get a specific silence by ID.
 **Example:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/silence/a1b2c3d4-e5f6-7890-abcd-ef1234567890" | jq .
 ```
 
@@ -265,7 +265,7 @@ Expire (delete) a silence.
 **Example:**
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X DELETE \
   "$VM_ALERTMANAGER_URL/api/v2/silence/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
@@ -285,10 +285,10 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # Conditional auth (works for both prod and local)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_ALERTMANAGER_URL/api/v2/alerts"
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_ALERTMANAGER_URL/api/v2/alerts"
 
 # POST with auth and JSON body
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -X POST -H "Content-Type: application/json" \
   -d '{"matchers": [...], "startsAt": "...", "endsAt": "...", "createdBy": "...", "comment": "..."}' \
   "$VM_ALERTMANAGER_URL/api/v2/silences"
@@ -311,7 +311,7 @@ AlertManager runs as an in-cluster pod. It may be unavailable due to:
 **Connectivity check:**
 
 ```bash
-curl -sf -o /dev/null -w "%{http_code}" ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -sf -o /dev/null -w "%{http_code}" ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_ALERTMANAGER_URL/api/v2/alerts" && echo " OK" || echo " UNREACHABLE"
 ```
 

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -25,7 +25,7 @@ Query VictoriaLogs HTTP API directly via curl. Covers log search, stats queries,
 All curl commands use conditional auth:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_LOGS_URL/select/logsql/query?query=*&start=2026-03-07T00:00:00Z&limit=10"
 ```
 
@@ -46,12 +46,12 @@ When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
 
 ```bash
 # Basic query (last hour, limit 100)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error' \
   "$VM_LOGS_URL/select/logsql/query?start=2026-03-07T00:00:00Z&limit=100"
 
 # With time range and field selection
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error' \
   "$VM_LOGS_URL/select/logsql/query?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&limit=50&fields=_time,_msg,level"
 ```
@@ -64,7 +64,7 @@ Response: JSON Lines (one JSON object per line). Pipe through `jq -s .` to colle
 
 ```bash
 # Count errors by level at a point in time
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} | stats by (level) count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query?time=2026-03-07T09:00:00Z" | jq .
 ```
@@ -77,7 +77,7 @@ Response: Prometheus-compatible JSON format.
 
 ```bash
 # Error count over time with 1h steps
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error | stats count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query_range?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=1h" | jq .
 ```
@@ -90,7 +90,7 @@ Response: Prometheus matrix format.
 
 ```bash
 # Log volume over time
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/hits?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=1h" | jq .
 ```
@@ -101,7 +101,7 @@ Parameters: `query` (required), `start` (required), `end`, `step` (required), `f
 
 ```bash
 # Discover field value distributions
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/facets?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z" | jq .
 ```
@@ -114,12 +114,12 @@ Parameters: `query` (required), `start` (required), `end`. Returns most frequent
 
 ```bash
 # Discover non-stream field names
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/field_names?start=2026-03-07T00:00:00Z" | jq .
 
 # Get values for a specific field
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/field_values?start=2026-03-07T00:00:00Z&field=level&limit=20" | jq .
 ```
@@ -128,12 +128,12 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # Discover stream field names (e.g., namespace, pod)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_names?start=2026-03-07T00:00:00Z" | jq .
 
 # Get values for a stream field
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_values?start=2026-03-07T00:00:00Z&field=namespace" | jq .
 ```
@@ -142,12 +142,12 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # List log stream identifiers
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/streams?start=2026-03-07T00:00:00Z&limit=20" | jq .
 
 # List stream IDs
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/stream_ids?start=2026-03-07T00:00:00Z" | jq .
 ```
@@ -235,22 +235,22 @@ All times use RFC3339 format: `2026-03-07T09:00:00Z`. Unix timestamps are NOT su
 
 ```bash
 # Quick error check for a namespace (last hour)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error' \
   "$VM_LOGS_URL/select/logsql/query?start=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)&limit=20"
 
 # Error rate over time
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error | stats count() as errors' \
   "$VM_LOGS_URL/select/logsql/stats_query_range?start=2026-03-07T00:00:00Z&step=1h" | jq .
 
 # Discover all namespaces with logs
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_values?start=2026-03-07T00:00:00Z&field=namespace" | jq .
 
 # Search by trace ID in logs
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=trace_id:"abc123def456"' \
   "$VM_LOGS_URL/select/logsql/query?start=2026-03-07T00:00:00Z&limit=50"
 ```

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -17,7 +17,9 @@ Query VictoriaLogs HTTP API directly via curl. Covers log search, stats queries,
 ```bash
 # $VM_LOGS_URL - base URL
 #   Example: export VM_LOGS_URL="https://vlselect.example.com"
-# $VM_AUTH_HEADER - auth header (set for prod, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty for local)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 ## Auth Pattern

--- a/plugins/query/skills/victorialogs-query/references/api-reference.md
+++ b/plugins/query/skills/victorialogs-query/references/api-reference.md
@@ -32,12 +32,12 @@ Response (JSON Lines — one object per line):
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error' \
   "$VM_LOGS_URL/select/logsql/query?start=2026-03-07T00:00:00Z&limit=100"
 
 # Collect JSON Lines into array for jq processing
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error' \
   "$VM_LOGS_URL/select/logsql/query?start=2026-03-07T00:00:00Z&limit=100" | jq -s .
 ```
@@ -76,7 +76,7 @@ Response (Prometheus-compatible JSON):
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} | stats by (level) count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query?time=2026-03-07T09:00:00Z" | jq .
 ```
@@ -112,7 +112,7 @@ Response (Prometheus matrix format):
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"} error | stats count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query_range?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=1h" | jq .
 ```
@@ -142,7 +142,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/hits?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=1h" | jq .
 ```
@@ -184,7 +184,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/facets?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z" | jq .
 ```
@@ -213,7 +213,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/field_names?start=2026-03-07T00:00:00Z" | jq '.[] | .name'
 ```
@@ -243,7 +243,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/field_values?start=2026-03-07T00:00:00Z&field=level&limit=20" | jq .
 ```
@@ -271,7 +271,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_names?start=2026-03-07T00:00:00Z" | jq '.[] | .name'
 ```
@@ -300,7 +300,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=*' \
   "$VM_LOGS_URL/select/logsql/stream_field_values?start=2026-03-07T00:00:00Z&field=namespace" | jq '.[] | .value'
 ```
@@ -327,7 +327,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/streams?start=2026-03-07T00:00:00Z&limit=20" | jq .
 ```
@@ -345,7 +345,7 @@ List internal stream IDs.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query={namespace="myapp"}' \
   "$VM_LOGS_URL/select/logsql/stream_ids?start=2026-03-07T00:00:00Z" | jq .
 ```

--- a/plugins/query/skills/victoriametrics-query/SKILL.md
+++ b/plugins/query/skills/victoriametrics-query/SKILL.md
@@ -27,7 +27,7 @@ Query VictoriaMetrics HTTP API directly via curl. Covers instant/range queries, 
 All curl commands use conditional auth — works for both prod and local:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_METRICS_URL/api/v1/query?query=up" | jq .
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_METRICS_URL/api/v1/query?query=up" | jq .
 ```
 
 When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
@@ -38,11 +38,11 @@ When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
 
 ```bash
 # Query at current time
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/query?query=up" | jq .
 
 # Query at specific time
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/query?query=up&time=2026-03-07T09:00:00Z" | jq .
 ```
 
@@ -51,7 +51,7 @@ Parameters: `query` (required), `time` (optional, RFC3339 or Unix seconds), `ste
 ### Range Query
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/query_range?query=rate(http_requests_total[5m])&start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=5m" | jq .
 ```
 
@@ -61,15 +61,15 @@ Parameters: `query` (required), `start` (required), `end` (optional), `step` (re
 
 ```bash
 # All label names
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/labels" | jq '.data[]'
 
 # Label values (label_name is a PATH parameter)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 
 # Label values filtered by series matcher
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={job="kubelet"}' \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 ```
@@ -78,7 +78,7 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # Find series matching selector
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="myapp"}' \
   "$VM_METRICS_URL/api/v1/series?limit=20" | jq '.data[].__name__'
 ```
@@ -89,7 +89,7 @@ Parameters: `match[]` (required), `start`, `end`, `limit`
 
 ```bash
 # Search by metric name keyword
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/metadata?metric=http_request&limit=10" | jq .
 ```
 
@@ -99,11 +99,11 @@ Parameters: `metric` (search keyword), `limit`.
 
 ```bash
 # All firing/pending alerts
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/alerts" | jq '.data.alerts[]'
 
 # All alerting and recording rules
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/rules" | jq '.data.groups[]'
 ```
 
@@ -111,19 +111,19 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # TSDB cardinality stats
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb" | jq .
 
 # Currently executing queries
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/active_queries" | jq .
 
 # Most frequent/slowest queries
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/top_queries?topN=10" | jq .
 
 # Version info
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/buildinfo" | jq .
 ```
 
@@ -131,13 +131,13 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # Export raw samples as JSON lines (one JSON object per line)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]=http_requests_total' \
   -d 'start=2026-03-07T00:00:00Z' -d 'end=2026-03-07T12:00:00Z' \
   "$VM_METRICS_URL/api/v1/export" | head -5
 
 # Export with reduced memory usage (for large exports)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="myapp"}' \
   -d 'start=2026-03-07T00:00:00Z' -d 'end=2026-03-07T01:00:00Z' \
   -d 'reduce_mem_usage=1' \
@@ -154,7 +154,7 @@ Also available: `/api/v1/export/csv` (CSV format), `/api/v1/export/native` (bina
 
 ```bash
 # Total number of active time series
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/series/count" | jq .
 ```
 
@@ -164,15 +164,15 @@ Note: can be slow on large databases and may return slightly inflated values.
 
 ```bash
 # Which metrics are being queried, and how often
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=20" | jq .
 
 # Metrics queried <= N times (find unused/rarely-used metrics)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=50&le=1" | jq .
 
 # Filter by metric name pattern
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?match_pattern=vm_&limit=20" | jq .
 ```
 
@@ -182,7 +182,7 @@ Parameters: `limit` (max results), `le` (max query count threshold — find metr
 
 ```bash
 # View non-default runtime flags (returns plain text, one flag per line — NOT JSON)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "${VM_METRICS_URL%%/select/*}/flags"
 ```
 
@@ -194,11 +194,11 @@ These are ROOT-level endpoints, NOT under `/api/v1/`. On cluster mode, strip the
 
 ```bash
 # Expand WITH expressions (returns text, not JSON)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "${VM_METRICS_URL%%/select/*}/expand-with-exprs?query=WITH(x=up)x"
 
 # Prettify MetricsQL query (returns JSON)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "${VM_METRICS_URL%%/select/*}/prettify-query?query=rate(x[5m])" | jq .
 ```
 
@@ -210,20 +210,20 @@ Root-level endpoints for debugging relabeling, downsampling, and retention confi
 
 ```bash
 # Debug metric relabeling rules — test how a metric is transformed
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'relabel_config=- target_label: cluster
   replacement: dev' \
   "${VM_METRICS_URL%%/select/*}/metric-relabel-debug"
 
 # Debug downsampling filters — test which downsampling rules match a metric
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'downsampling_period=30d:5m,180d:1h' \
   "${VM_METRICS_URL%%/select/*}/downsampling-filters-debug"
 
 # Debug retention filters — test which retention policy applies to a metric
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'retention_period=2y,{env="dev"}:30d' \
   "${VM_METRICS_URL%%/select/*}/retention-filters-debug"
@@ -258,16 +258,16 @@ All times accept RFC3339 (`2026-03-07T09:00:00Z`) or Unix seconds (`1709769600`)
 
 ```bash
 # Check if a metric exists
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/query?query=count({__name__=~\"http_request.*\"})" | jq '.data.result[].value[1]'
 
 # Get all namespaces with active pods
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={__name__="kube_pod_info"}' \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 
 # Rate of errors over last hour
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=sum(rate(http_requests_total{code=~"5.."}[5m])) by (namespace)' \
   "$VM_METRICS_URL/api/v1/query" | jq '.data.result[] | {ns: .metric.namespace, rate: .value[1]}'
 ```

--- a/plugins/query/skills/victoriametrics-query/SKILL.md
+++ b/plugins/query/skills/victoriametrics-query/SKILL.md
@@ -19,7 +19,9 @@ Query VictoriaMetrics HTTP API directly via curl. Covers instant/range queries, 
 # $VM_METRICS_URL - base URL
 #   cluster: export VM_METRICS_URL="https://vmselect.example.com/select/0/prometheus"
 #   single: export VM_METRICS_URL="http://localhost:8428"
-# $VM_AUTH_HEADER - auth header (set for prod, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty for local)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 ## Auth Pattern

--- a/plugins/query/skills/victoriametrics-query/references/api-reference.md
+++ b/plugins/query/skills/victoriametrics-query/references/api-reference.md
@@ -38,7 +38,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/query?query=up&time=2026-03-07T09:00:00Z" | jq .
 ```
 
@@ -74,7 +74,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=rate(http_requests_total[5m])' \
   "$VM_METRICS_URL/api/v1/query_range?start=2026-03-07T00:00:00Z&end=2026-03-07T12:00:00Z&step=5m" | jq .
 ```
@@ -103,7 +103,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/labels" | jq '.data[]'
 ```
 
@@ -130,11 +130,11 @@ Examples:
 
 ```bash
 # All values for "namespace" label
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 
 # Values filtered by series
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={job="kubelet"}' \
   "$VM_METRICS_URL/api/v1/label/namespace/values" | jq '.data[]'
 ```
@@ -164,7 +164,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]={namespace="myapp"}' \
   "$VM_METRICS_URL/api/v1/series?limit=20" | jq '.data[]'
 ```
@@ -196,7 +196,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/metadata?metric=http_request&limit=10" | jq .
 ```
 
@@ -228,7 +228,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/alerts" | jq '.data.alerts[]'
 ```
 
@@ -262,7 +262,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/rules" | jq '.data.groups[] | {name, rules: [.rules[] | select(.state != "inactive") | .name]}'
 ```
 
@@ -283,7 +283,7 @@ Key fields in response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/tsdb" | jq '{total: .data.totalSeries, top_metrics: .data.seriesCountByMetricName[:5]}'
 ```
 
@@ -294,7 +294,7 @@ Currently executing queries. No parameters.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/active_queries" | jq .
 ```
 
@@ -310,7 +310,7 @@ Most frequent and slowest queries.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/top_queries?topN=10" | jq '.data.topByCount[:5]'
 ```
 
@@ -321,7 +321,7 @@ Version information. No parameters.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/buildinfo" | jq .
 ```
 
@@ -348,7 +348,7 @@ Response: JSON lines (one JSON object per line, NOT wrapped in standard API resp
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'match[]=http_requests_total' \
   -d 'start=2026-03-07T00:00:00Z' -d 'end=2026-03-07T12:00:00Z' \
   -d 'reduce_mem_usage=1' \
@@ -389,11 +389,11 @@ Example:
 
 ```bash
 # Metrics queried 0 or 1 times (candidates for removal)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?limit=50&le=1" | jq .
 
 # Metrics matching prefix
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_METRICS_URL/api/v1/status/metric_names_stats?match_pattern=vm_&limit=20" | jq .
 ```
 
@@ -404,7 +404,7 @@ Root-level endpoint. Returns runtime flags that differ from defaults.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "${VM_METRICS_URL%%/select/*}/flags" | jq .
 ```
 
@@ -446,7 +446,7 @@ Test how metric relabeling rules transform a metric.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'relabel_config=- target_label: cluster
   replacement: dev' \
@@ -465,7 +465,7 @@ Test which downsampling rules match a given metric.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'downsampling_period=30d:5m,180d:1h' \
   "${VM_METRICS_URL%%/select/*}/downsampling-filters-debug"
@@ -483,7 +483,7 @@ Test which retention policy applies to a given metric.
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   -d 'metric=foo{bar="baz"}' \
   -d 'retention_period=2y,{env="dev"}:30d' \
   "${VM_METRICS_URL%%/select/*}/retention-filters-debug"
@@ -517,7 +517,7 @@ Note: All three debug endpoints return HTML. For interactive use, access VMUI at
 For POST requests, use `--data-urlencode` with curl to properly encode query parameters containing special characters:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'query=sum(rate(http_requests_total{code=~"5.."}[5m])) by (namespace)' \
   "$VM_METRICS_URL/api/v1/query"
 ```

--- a/plugins/query/skills/victoriatraces-query/SKILL.md
+++ b/plugins/query/skills/victoriatraces-query/SKILL.md
@@ -27,7 +27,7 @@ IMPORTANT: The Jaeger API lives under `/select/jaeger/api/...`, NOT root `/api/.
 All curl commands use conditional auth:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services" | jq .
 ```
 
@@ -48,7 +48,7 @@ When `VM_AUTH_HEADER` is empty, `-H` flag is omitted automatically.
 ### List Services
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services" | jq '.data[]'
 ```
 
@@ -57,7 +57,7 @@ No parameters. Returns all traced service names. Always start here to discover w
 ### Service Operations
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services/my-service/operations" | jq '.data[]'
 ```
 
@@ -67,19 +67,19 @@ curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
 
 ```bash
 # Basic search (last hour, limit 20) — timestamps in microseconds (16 digits)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=20" | jq .
 
 # With operation and duration filter
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&operation=GET+/api/health&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&minDuration=100ms&limit=20" | jq .
 
 # With tag filter (Jaeger JSON format)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&tags=%7B%22http.status_code%22%3A%22500%22%7D&limit=20" | jq .
 
 # With tag filter (VictoriaTraces extended format — key=value pairs, space-separated)
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'tags=http.status_code=500 resource_attr:service.namespace=production' \
   "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=20" | jq .
 ```
@@ -89,7 +89,7 @@ Parameters: `service` (required), `operation`, `start` (Unix µs), `end` (Unix �
 ### Get Trace by ID
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces/abc123def456789" | jq .
 ```
 
@@ -99,7 +99,7 @@ Returns full trace with all spans. If trace not found, response contains `"error
 
 ```bash
 # Dependencies for the last hour
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/dependencies?endTs=$(date +%s%3N)&lookback=3600000" | jq '.data[]'
 ```
 
@@ -164,20 +164,20 @@ date +%s%3N
 
 ```bash
 # Full discovery workflow: services -> operations -> traces
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/services" | jq '.data[]'
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/services/my-service/operations" | jq '.data[]'
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=10" | jq '.data[] | .traceID'
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/services" | jq '.data[]'
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/services/my-service/operations" | jq '.data[]'
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&limit=10" | jq '.data[] | .traceID'
 
 # Find slow traces (> 5 seconds)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&start=$(($(date +%s%6N) - 3600000000))&end=$(date +%s%6N)&minDuration=5s&limit=20" | jq '.data[] | {traceID: .traceID, spans: (.spans | length)}'
 
 # Look up a trace ID found in logs
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces/abc123def456789" | jq '.data[].spans[] | {operation: .operationName, duration_ms: (.duration / 1000), service: .processID}'
 
 # Map service dependencies (last 24 hours) — dependencies use milliseconds
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/dependencies?endTs=$(date +%s%3N)&lookback=86400000" | jq '.data[]'
 ```
 

--- a/plugins/query/skills/victoriatraces-query/SKILL.md
+++ b/plugins/query/skills/victoriatraces-query/SKILL.md
@@ -17,7 +17,9 @@ Query VictoriaTraces Jaeger-compatible HTTP API directly via curl. Covers servic
 ```bash
 # $VM_TRACES_URL - base URL including /select/jaeger prefix
 #   Example: export VM_TRACES_URL="https://vtselect.example.com/select/jaeger"
-# $VM_AUTH_HEADER - auth header (set for prod, empty for local)
+# $VM_AUTH_HEADER - full HTTP header line (set for prod, empty for local)
+#   Prod:  export VM_AUTH_HEADER="Authorization: Bearer <token>"
+#   Local: export VM_AUTH_HEADER=""
 ```
 
 IMPORTANT: The Jaeger API lives under `/select/jaeger/api/...`, NOT root `/api/...`. The `$VM_TRACES_URL` env var already includes the `/select/jaeger` prefix, so all endpoints below use `$VM_TRACES_URL/api/...`.

--- a/plugins/query/skills/victoriatraces-query/references/api-reference.md
+++ b/plugins/query/skills/victoriatraces-query/references/api-reference.md
@@ -29,7 +29,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services" | jq '.data[]'
 ```
 
@@ -52,7 +52,7 @@ Response:
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/services/my-service/operations" | jq '.data[]'
 ```
 
@@ -133,24 +133,24 @@ Examples:
 # Basic search — timestamps in microseconds (16 digits)
 END_US=$(date +%s%6N)
 START_US=$((END_US - 3600000000))
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&start=${START_US}&end=${END_US}&limit=20" | jq .
 
 # With operation filter
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&operation=GET+/api/health&start=${START_US}&end=${END_US}&limit=10" | jq .
 
 # With duration filter
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces?service=my-service&start=${START_US}&end=${END_US}&minDuration=1s&maxDuration=10s&limit=20" | jq .
 
 # With tag filter — Jaeger JSON format (URL-encoded)
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'tags={"http.status_code":"500"}' \
   "$VM_TRACES_URL/api/traces?service=my-service&start=${START_US}&end=${END_US}&limit=20" | jq .
 
 # With tag filter — VictoriaTraces extended format (key=value, space-separated)
-curl -s -G ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s -G ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   --data-urlencode 'tags=error=unset resource_attr:service.namespace=production' \
   "$VM_TRACES_URL/api/traces?service=my-service&start=${START_US}&end=${END_US}&limit=20" | jq .
 ```
@@ -178,11 +178,11 @@ Note: This returns an HTTP 200 with errors in the response body, NOT an HTTP 404
 Example:
 
 ```bash
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces/abc123def456789" | jq .
 
 # Check if trace was found
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/traces/abc123def456789" | jq 'if .errors then "NOT FOUND: " + .errors[0].msg else "Found: " + (.data[0].spans | length | tostring) + " spans" end'
 ```
 
@@ -217,11 +217,11 @@ Example:
 
 ```bash
 END_MS=$(date +%s%3N)
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/dependencies?endTs=${END_MS}&lookback=3600000" | jq '.data[]'
 
 # Last 24 hours
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} \
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} \
   "$VM_TRACES_URL/api/dependencies?endTs=${END_MS}&lookback=86400000" | jq '.data[] | "\(.parent) -> \(.child) (\(.callCount) calls)"'
 ```
 


### PR DESCRIPTION
## Problem

The conditional auth header pattern `${VAR:+-H "$VAR"}` works in bash but fails under zsh's default behavior. zsh does not perform word splitting on `${param:+word}` substitutions (no `SH_WORD_SPLIT`), so the entire expression collapses into a single argument:

```
curl -s '-H Authorization: Bearer xxx' "$URL"
       └─────── one arg ───────────┘
```

curl then receives no proper `-H` flag and the request goes out without auth, producing 401 against any auth-protected endpoint.

This affects all macOS users (zsh is default since Catalina), including anyone running these skills via Claude Code's Bash tool on macOS.

## Fix

Split the conditional into two separate `${VAR:+...}` expansions so `-H` and the header value are guaranteed to remain distinct tokens in both bash and zsh, while preserving the "omit `-H` entirely when the variable is empty" behavior for local/no-auth setups.

```diff
-curl -s ${VM_AUTH_HEADER:+-H "$VM_AUTH_HEADER"} "$URL"
+curl -s ${VM_AUTH_HEADER:+-H} ${VM_AUTH_HEADER:+"$VM_AUTH_HEADER"} "$URL"
```

## Scope

14 files across all four query/diagnostics skills:
- `victoriametrics-query`, `victorialogs-query`, `victoriatraces-query`, `alertmanager-query`
- `victoriametrics-cardinality-analysis`, `victoriametrics-unused-metrics-analysis`
- `investigating-with-observability` agents

180 line replacements, mechanical pattern swap only.

## Verification

Tested all four combinations:

| shell | header set | result |
|-------|------------|--------|
| zsh   | yes (prod) | OK 200 |
| bash  | yes (prod) | OK 200 |
| zsh   | empty (local) | OK 200, no `-H` sent |
| bash  | empty (local) | OK 200, no `-H` sent |