### PR TITLE
Add vmanomaly skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "VictoriaMetrics"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "plugins": [
     {
       "name": "query",
@@ -14,6 +14,11 @@
       "name": "diagnostics",
       "source": "./plugins/diagnostics",
       "description": "Query trace analysis and multi-signal investigation tools"
+    },
+    {
+      "name": "vmanomaly",
+      "source": "./plugins/vmanomaly",
+      "description": "Configure, operate, tune, and review VictoriaMetrics Anomaly Detection"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These skills help AI agents and automation tools understand, operate, and troubl
 |--------|--------|---------|
 | [query](plugins/query/) | victoriametrics-query, victorialogs-query, victoriatraces-query, alertmanager-query | Query metrics, logs, traces, and alerts |
 | [diagnostics](plugins/diagnostics/) | vm-trace-analyzer, investigating-with-observability, victoriametrics-cardinality-analysis, victoriametrics-unused-metrics-analysis, stream-aggregation-helper | Query trace analysis, multi-signal investigations, cardinality optimization, unused metric detection, stream aggregation design |
+| [vmanomaly](plugins/vmanomaly/) | vmanomaly-query, vmanomaly-config, vmanomaly-review | Operate the vmanomaly API, build and tune anomaly-detection configurations, and review detection quality |
 
 ## Installation
 
@@ -32,6 +33,9 @@ npx skills add VictoriaMetrics/skills --skill vm-trace-analyzer
 npx skills add VictoriaMetrics/skills --skill victoriametrics-cardinality-analysis
 npx skills add VictoriaMetrics/skills --skill victoriametrics-unused-metrics-analysis
 npx skills add VictoriaMetrics/skills --skill stream-aggregation-helper
+npx skills add VictoriaMetrics/skills --skill vmanomaly-query
+npx skills add VictoriaMetrics/skills --skill vmanomaly-config
+npx skills add VictoriaMetrics/skills --skill vmanomaly-review
 ```
 
 ### Via Claude Code plugin marketplace
@@ -47,6 +51,7 @@ Install plugins:
 ```
 /plugin install query@victoriametrics-tools # Query VictoriaStack components and AlertManager
 /plugin install diagnostics@victoriametrics-tools # Troubleshooting and query trace analysis
+/plugin install vmanomaly@victoriametrics-tools # Configure, operate, tune, and review anomaly detection
 ```
 
 ## Skills
@@ -70,6 +75,18 @@ Install plugins:
 | victoriametrics-unused-metrics-analysis | Find unused and rarely-queried metrics, then suggest drop rules and relabel configs to reduce waste |
 | stream-aggregation-helper | Design vmagent stream aggregation rules — gate, intake, pick interval/output/by-without, generate YAML, plan rollout, verify with `vm_streamaggr_*` |
 
+### vmanomaly plugin
+
+| Skill | Purpose |
+|-------|---------|
+| vmanomaly-query | Operate vmanomaly v1.30+ HTTP APIs for health, compatibility, schemas, profiling, shared autotune, validation, and bounded detection tasks |
+| vmanomaly-config | Triage static alerting versus ML, select and tune a model from real time-series characteristics, and produce validated deployment artifacts |
+| vmanomaly-review | Audit an existing configuration against runtime schemas and real data, reproduce detections, and verify proposed fixes |
+
+Each vmanomaly skill is independently installable. When query or diagnostics skills are also
+available, the vmanomaly workflows can use them for metric/log discovery, cardinality checks,
+existing-alert review, and multi-signal incident correlation.
+
 ## Usage
 
 Once installed, skills are available as slash commands and are also triggered automatically when Claude detects a matching request:
@@ -84,6 +101,9 @@ Once installed, skills are available as slash commands and are also triggered au
 /diagnostics:victoriametrics-cardinality-analysis  - cardinality analysis and optimization recommendations
 /diagnostics:victoriametrics-unused-metrics-analysis - find unused metrics and suggest drop rules
 /diagnostics:stream-aggregation-helper             - design and verify stream aggregation rules
+/vmanomaly:vmanomaly-query                         - inspect and operate the vmanomaly API
+/vmanomaly:vmanomaly-config                        - build and tune a validated anomaly configuration
+/vmanomaly:vmanomaly-review                        - audit an existing anomaly configuration
 ```
 
 **Example prompts that trigger skills:**
@@ -97,6 +117,9 @@ Once installed, skills are available as slash commands and are also triggered au
 - "Which metrics have the highest cardinality?" → `victoriametrics-cardinality-analysis`
 - "Find metrics that nobody queries" → `victoriametrics-unused-metrics-analysis`
 - "Help me aggregate this high-cardinality metric at vmagent" → `stream-aggregation-helper`
+- "Profile this query and choose a vmanomaly model" → `vmanomaly-config`
+- "Check whether my persisted vmanomaly state is compatible with v1.30" → `vmanomaly-query`
+- "Review why this anomaly model produces too many detections" → `vmanomaly-review`
 
 ## Environment Variables
 
@@ -107,6 +130,9 @@ VM_METRICS_URL        # VictoriaMetrics query endpoint (e.g., http://localhost:8
 VM_LOGS_URL           # VictoriaLogs endpoint (e.g., http://localhost:9428)
 VM_TRACES_URL         # VictoriaTraces with /select/jaeger prefix (e.g., http://localhost:10428/select/jaeger)
 VM_ALERTMANAGER_URL   # AlertManager endpoint (optional)
+VM_ANOMALY_URL        # vmanomaly endpoint, including path prefix if configured (e.g., http://localhost:8490)
 VM_AUTH_HEADER        # Full HTTP header line, e.g. "Authorization: Bearer <token>"
-                      # (empty for local, set for prod)
+                      # (used by query/diagnostic skills; empty for local, set for prod)
+VM_CURL_CONFIG        # vmanomaly plugin: mode-0600 curl config containing the auth header
+                      # (use /dev/null for unauthenticated local instances)
 ```

--- a/plugins/vmanomaly/.claude-plugin/plugin.json
+++ b/plugins/vmanomaly/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "vmanomaly",
+  "description": "Configure, operate, and review VictoriaMetrics Anomaly Detection. Profile time series, select and tune models, validate configurations, run bounded detection tasks, and check persisted-state compatibility.",
+  "version": "1.0.0",
+  "author": {
+    "name": "VictoriaMetrics"
+  },
+  "homepage": "https://victoriametrics.com/products/victoriametrics-anomaly-detection/",
+  "repository": "https://github.com/VictoriaMetrics/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "victoriametrics",
+    "vmanomaly",
+    "anomaly-detection",
+    "autotune",
+    "forecasting",
+    "machine-learning",
+    "observability"
+  ]
+}

--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: vmanomaly-config
+description: >
+  Design, tune, validate, and test VictoriaMetrics vmanomaly configurations for known metrics
+  or LogsQL queries. Use when choosing static alerting versus ML, selecting a vmanomaly model,
+  configuring Temporal Envelope, building deployment YAML, tuning anomaly sensitivity, or
+  creating VMAlert rules. Trigger on anomaly configuration, model selection, shared autotune,
+  seasonal anomaly detection, forecasting, or "how should I monitor this metric?" Do not use
+  for open-ended discovery across unknown signals.
+allowed-tools: Bash(curl:*), Bash(jq:*), Read
+---
+
+# vmanomaly configuration builder
+
+Turn a known monitoring intent into a validated vmanomaly v1.30+ configuration. ML must earn its
+operational cost: first decide whether a static rule expresses the failure condition more clearly.
+
+Read `references/model-selection.md` before selecting a model or its parameters.
+When producing a continuously running deployment, also read
+`references/deployment-readiness.md` and apply only the controls whose conditions match.
+
+## Environment
+
+```bash
+export VM_ANOMALY_URL="https://vmanomaly.example.com"
+# Use /dev/null without authentication. For authenticated instances, point this to a mode-0600
+# curl config containing: header = "Authorization: Bearer <token>"
+export VM_CURL_CONFIG="${VM_CURL_CONFIG:-/dev/null}"
+```
+
+Include any configured path prefix in `VM_ANOMALY_URL`. Never print or create the credential file.
+Ask for the URL when it is unavailable.
+
+## Workflow
+
+### 1. Establish intent and obtain the exact query
+
+Collect or infer:
+
+- the exact PromQL/MetricsQL or LogsQL expression;
+- spikes, drops, level shifts, seasonal breaks, or trend breaks to detect;
+- direction: `above_expected`, `below_expected`, or both;
+- desired reaction time and query step;
+- IANA timezone used by the production query and calendar profiles;
+- known physical bounds and insignificant absolute/relative deviations;
+- sensitivity preference and acceptable upper detection rate.
+
+If the model-query field is empty but the user already supplied a query, use it for profiling and
+recommend placing it in the UI query input. If no query exists, ask for one. Do not invent a
+production query from a metric description.
+
+When installed, `victoriametrics-query` or `victorialogs-query` may help discover names, labels,
+and valid expressions. Their absence must not block this skill.
+
+### 2. Triage static alerting versus ML
+
+Prefer a static VMAlert rule when a clear bad value exists:
+
+| Signal shape | Better first choice |
+|---|---|
+| near-zero error/restart count | `> threshold for duration` |
+| monotonic capacity fill | percentage threshold plus `predict_linear` |
+| binary/up-down state | direct threshold, `absent()`, or `changes()` |
+| expiry or hard safety limit | direct threshold |
+
+Use vmanomaly when normal varies by time, instance, workload, or a drifting baseline; when daily,
+weekly, monthly, or holiday structure matters; or when a cross-series relationship is the signal.
+Present this decision before spending an autotune budget.
+
+### 3. Run the runtime preflight
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/health" | jq .
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/server/buildinfo" | jq .
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/compatibility" | jq .
+```
+
+Treat the compatibility response as a preflight, not a cleanup action:
+
+- no stored state is healthy;
+- report `drop_everything`, models to purge, or reader-data cleanup;
+- never delete state without explicit user approval;
+- use `?version_to=X.Y.Z` for a planned upgrade.
+
+Only the GET compatibility check exists in v1.30.
+
+### 4. Profile real data
+
+Use the same `step` that the final task/config will use:
+
+```bash
+QUERY='<exact-query>'
+TIMEZONE='<IANA-timezone>'
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode "query=$QUERY" \
+  --data-urlencode 'start=<unix-seconds>' \
+  --data-urlencode 'end=<unix-seconds>' \
+  --data-urlencode 'step=5m' \
+  --data-urlencode "timezone=$TIMEZONE" \
+  --data-urlencode 'limit=100' \
+  "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
+```
+
+Use measured trend, daily/weekly/monthly profiles, shape, eligibility, and coverage rather than
+guessing from the metric name. A limited result is a sample. If a limited read returns a split-
+chunk 422, shorten the interval or use a coarser step.
+
+### 5. Discover and select a supported model
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/models" | jq .
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode 'model_class=temporal_envelope' \
+  "$VM_ANOMALY_URL/api/v1/model/schema" | jq .
+```
+
+Use the live alias list and schema as authoritative. Rebuild the model spec when changing class;
+never carry stale parameters across classes.
+
+Default hierarchy:
+
+1. For complex operational profiles with trend, calendar patterns, holidays, persistent shifts,
+   or forecasts, start with `temporal_envelope`.
+2. For simple non-seasonal data, prefer `mad_online`; use `zscore_online` when the distribution is
+   stable/light-tailed and standard-deviation magnitude is meaningful.
+3. For aligned channels where their relationship is the anomaly, start with
+   `temporal_envelope_multivariate`.
+4. Deprioritize offline models; retain them only for legacy use or when comparative validation
+   establishes a clear benefit.
+
+### 6. Map domain knowledge to public controls
+
+- Fix `detection_direction` when business intent is known.
+- In deployable YAML, set `reader.queries.<alias>.data_range` (or the reader-level default) for
+  bounded metrics. The service propagates that query domain into model execution.
+- For an ad-hoc detection task, `model_spec.data_range` is accepted and mapped to its temporary
+  reader query; common model schemas expose it for this execution contract.
+- Set model-level `clip_predictions` only when forecast and interval outputs should be clipped to
+  that domain.
+- Map insignificant absolute/relative deviations to `min_dev_from_expected` and
+  `min_rel_dev_from_expected`.
+- Use `min_n_samples_seen` to suppress scores during cold-start; express its duration as samples
+  multiplied by query step.
+- For stable MAD, Z-score, or online-quantile data, consider `history_strength > 1` instead of many
+  extra fit cycles; keep enough history to cover every required seasonal phase.
+- Select only calendar presets supported by the profile. Temporal Envelope profiles are timezone-
+  and DST-aware; set `reader.queries.<alias>.tz` (or the reader-level `tz`) to the same IANA
+  timezone used during profiling.
+- Keep `forecast_at` empty unless the user needs future-state forecasting or capacity planning.
+- Keep multivariate `groupby`, holidays, and other domain structure fixed during autotune.
+
+### 7. Choose direct configuration or shared autotune
+
+For a direct configuration, begin with schema defaults and change only justified controls.
+
+For shared autotune, first select the model class. State the trial/time budget, then create one
+bounded task. Use causal exact validation for online models:
+
+```bash
+jq -n --arg query "$QUERY" --arg timezone "$TIMEZONE" '{
+    query:$query,
+    "tuned_class_name":"temporal_envelope",
+    "anomaly_percentage":0.02,
+    "start":1710000000,
+    "end":1711209600,
+    "step":"5m",
+    timezone:$timezone,
+    "limit":100,
+    "use_profile_hints":true,
+    "optimization_params":{"n_trials":64,"timeout":30,"exact":true,"optimize_complexity":true},
+    "frozen_params":{"detection_direction":"above_expected"}
+  }' | curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' --data-binary @- \
+  "$VM_ANOMALY_URL/api/v1/autotune/tasks" | jq .
+```
+
+Poll `GET /api/v1/autotune/tasks/{task_id}` sequentially. On success, use the concrete
+`result_data.data.modelConfig`, validate it, and test it. Do not substitute `class: auto`; that
+wrapper retunes during each fit and is a separate, explicitly chosen lifecycle.
+
+### 8. Validate and test
+
+Validate the model spec:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' \
+  -d @model.json "$VM_ANOMALY_URL/api/v1/model/validate" | jq .
+```
+
+Validate full YAML without applying it:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/yaml' --data-binary @config.yaml \
+  "$VM_ANOMALY_URL/api/v1/config/validate" | jq .
+```
+
+Then check capacity and run a bounded detection task using the validated model:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
+
+jq -n --arg query "$QUERY" --slurpfile model model.json '{
+    query:$query,
+    step:"5m",
+    fit_window:"30d",
+    fit_every:"1000w",
+    start_infer_s:1710000000,
+    end_infer_s:1710086400,
+    exact:true,
+    model_spec:$model[0]
+  }' | curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' --data-binary @- \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks" | jq .
+
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks/<task_id>" | jq .
+```
+
+Poll the returned task ID sequentially until `done`, `error`, or `canceled`. For online models use
+`exact:true` and default to an effectively disabled refit cadence such as `fit_every: 1000w`, so
+the initial fit evolves causally during inference. Configure periodic refits only when explicitly
+needed.
+
+Evaluate detections visually and against known events. Without ground-truth labels, call the
+observed fraction a **detection rate**, not a false-positive rate. Ask the user which detections
+were useful before tightening the model.
+
+### 9. Deliver deployable artifacts
+
+Provide:
+
+- the static rule or complete vmanomaly YAML;
+- a VMAlert rule for the produced anomaly score;
+- rationale tied to profile evidence and business intent;
+- query step, fit window/cadence, warmup, expected reaction time, and resource caveats;
+- validation/test results and assumptions requiring production verification.
+- self-monitoring integration, with the official dashboard and alert rules recommended for
+  production rather than relying on point-in-time health checks.
+- justified state restoration, retention, hot-reload, persistence, and workload-distribution
+  choices from `references/deployment-readiness.md`.
+
+Generated `/api/vmanomaly/config.yaml` and `/api/vmanomaly/example-alert-rule.yaml` output is a
+starting point, not proof of correctness. Validate it before delivery.
+
+## Safety
+
+- API validation and tasks do not deploy or hot-reload configuration.
+- Obtain approval before applying configs, creating persistent alert rules, or deleting state.
+- Bound samples, time ranges, series limits, trial counts, and concurrent tasks.
+- Never infer that empty data means the metric does not exist until the query and labels are checked.

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
@@ -1,0 +1,90 @@
+# vmanomaly deployment-readiness reference
+
+Use this when a validated configuration will run continuously. Keep small deployments simple and
+add operational controls only when their conditions apply. The official
+[installation guide](https://docs.victoriametrics.com/anomaly-detection/quickstart/#how-to-install-and-run-vmanomaly)
+links Docker, Docker Compose, Helm, and Operator deployment paths.
+
+## Stateful online operation
+
+For periodic online models, prefer one initial fit followed by causal inference updates. Protect
+that accumulated state across restarts:
+
+- set `settings.restore_state: true`;
+- enable on-disk model and reader-data storage, which state restoration requires;
+- mount the dump directories on durable storage rather than an ephemeral container filesystem;
+- run the compatibility preflight before upgrades or changing persisted-state layout.
+
+State reuse is exact only while model, query, and scheduler identity remains compatible. Parameter,
+query, or sharding changes may invalidate or relocate some state and trigger a fresh fit.
+
+## Retention and high churn
+
+Configure [`settings.retention`](https://docs.victoriametrics.com/anomaly-detection/components/settings/#retention)
+when labelsets appear and disappear, especially with online models or state restoration:
+
+```yaml
+settings:
+  restore_state: true
+  retention:
+    ttl: 7d
+    check_interval: 1h
+```
+
+Treat these values as an example, not a default:
+
+- choose `ttl` longer than the longest legitimate absence of an active series; otherwise an
+  intermittent but valid model may cold-start when it returns;
+- use a shorter TTL for high-churn ephemeral labelsets and a longer one for intermittent business
+  series;
+- keep `check_interval < ttl` and below the smallest configured `fit_every`;
+- if `ttl` exceeds an offline model's `fit_every`, refitting normally replaces its state before
+  retention can clean it.
+
+Retention removes stale model/training artifacts; it does not replace source-side metric retention
+or output-series lifecycle policies.
+
+## Configuration lifecycle
+
+Use content-polled hot reload when configuration files or Kubernetes ConfigMaps are managed
+externally:
+
+- start with `--watch` and set `-configCheckInterval` only when the default check cadence is
+  unsuitable;
+- validate the full YAML before rollout;
+- monitor `vmanomaly_config_last_reload_successful` and reload counters;
+- combine hot reload with state restoration to reuse compatible state.
+
+Do not promise zero model reinitialization: changing model parameters, queries, schedulers, or shard
+assignment may require new state.
+
+## Workload and resource controls
+
+| Control | Recommend when | Avoid as a blanket default |
+|---|---|---|
+| `scheduler.scatter_infer_jobs: true` | many queries, short `infer_every`, `n_workers > 1`, synchronized bursts | one or a few cheap queries |
+| `settings.n_workers > 1` | independent models/series and available CPU | tightly constrained single-core deployments |
+| on-disk mode | model/data cardinality causes RAM pressure or state restoration is enabled | latency-sensitive small in-memory workloads, unless needed for restoration |
+| query-range splitting | long fit reads hit memory, timeout, or datasource limits | bounded reads already complete reliably |
+| `reader.series_processing_batch_size` tuning | measured processing memory/throughput bottleneck | changing the default without evidence |
+
+Keep `infer_every` aligned with the required alert reaction time. Scattering smooths work within
+that interval; it does not increase total capacity by itself.
+
+## Scale-out and high availability
+
+Introduce sharding only after one instance is resource-bound or when isolation is operationally
+required. Add replication only for an explicit availability objective. Replicated writers require
+VictoriaMetrics-side deduplication to avoid duplicate output samples. Hot reload can redistribute
+sub-configurations between shards, reducing state-restoration reuse.
+
+## Production handoff
+
+Before presenting a configuration as deployment-ready, report:
+
+- installation path and required persistent volumes/environment paths;
+- state restoration and retention decisions;
+- inference/refit cadence and expected reaction time;
+- worker/scattering/on-disk choices with workload evidence;
+- validation, compatibility, self-monitoring dashboard, and alert-rule status;
+- upgrade, rollback, and cold-start assumptions.

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
@@ -1,0 +1,171 @@
+# vmanomaly v1.30 model-selection reference
+
+Use this after profiling real data. Runtime `/api/v1/models` and `/api/v1/model/schema` results
+override static examples.
+
+## Contents
+
+- [Decision tree](#decision-tree)
+- [Temporal Envelope](#temporal-envelope)
+- [Simple online models](#simple-online-models)
+- [Offline and specialized alternatives](#offline-and-specialized-alternatives)
+- [Fit-window and cadence guidance](#fit-window-and-cadence-guidance)
+- [Autotune guidance](#autotune-guidance)
+
+## Decision tree
+
+```text
+Can a static rule clearly express failure?
+├─ yes: use VMAlert/static alerting; adapt a proven rule when available
+└─ no
+   ├─ trend, calendar patterns, holidays, shifts, or forecast? → temporal_envelope
+   ├─ simple, non-seasonal profile
+   │  ├─ skewed/heavy-tailed/spike-contaminated → mad_online
+   │  └─ stable/light-tailed and magnitude matters → zscore_online
+   ├─ seasonal quantiles with absent/slow trend → quantile_online
+   └─ cross-series relationship is the signal
+      └─ temporal_envelope_multivariate
+```
+
+For deterministic failures, consult
+[Awesome Prometheus Alerts](https://samber.github.io/awesome-prometheus-alerts/) for reusable static
+rules before creating an ML detector. Adapt rules to the actual metric semantics and validate them;
+do not apply presets blindly.
+
+Do not call hour-of-day seasonality “weekly.” HOD is a daily local-hour pattern; DOW is weekly.
+
+## Temporal Envelope
+
+Temporal Envelope is the preferred online tradeoff for complex operational and business data. It
+models evolving trend, robust residual bounds, calendar and holiday behavior, persistent shifts,
+and optional forecasts with bounded online state.
+
+Starting public controls:
+
+| Field | Default | Practical guidance |
+|---|---:|---|
+| `quantiles` | `[0.25, 0.75]` | two ordered residual probabilities in `[0,1]` |
+| `iqr_threshold` | `2.0` | ordinary width; experiment within `1`–`4` |
+| `alpha` | `0.005` | trend reactivity; experiment around `0.0025`–`0.02` |
+| `loss_reactivity` | `5.0` | start within `1`–`5`; lower is more conservative, higher adapts faster |
+| `min_n_samples_seen` | `16` | zero anomaly scores during warmup |
+| `changepoint_window` | `16` | same-direction samples before persistent-shift adaptation |
+| `seasonalities` | HOD/DOW smooth | remove unsupported profiles; `[]` is valid |
+| `holidays` | `{}` | country/special-event effects; shape learned internally |
+| `forecast_at` | `[]` | keep empty for current-state detection; add only for future-state or capacity-planning needs |
+
+Calendar presets:
+
+- `hod_smooth`, `hod_spiky`, `hod_plateau`
+- `dow_smooth`, `dow_spiky`, `dow_plateau`
+- `weekpart_plateau`
+- `month_smooth`, `month_plateau`
+
+`smooth` means a gradual curve, `spiky` a narrow recurring peak, and `plateau` a sustained phase.
+Choose only evidence-backed profiles. They use the configured civil timezone and remain aligned
+across DST transitions.
+
+Example:
+
+```yaml
+models:
+  workload:
+    class: temporal_envelope
+    queries: [request_rate]
+    seasonalities: [hod_smooth, dow_smooth]
+    holidays:
+      countries: [US]
+      group: true
+```
+
+### Multivariate form
+
+Use `temporal_envelope_multivariate` only when aligned channel relationships are meaningful. Each
+channel retains its own trend/calendar profile, while dependencies contribute to one joint score.
+
+- default output is the one joint `anomaly_score` to limit cardinality;
+- `dependency_rank` defaults to `8`; `0` disables dependency features;
+- `score_aggregation` defaults to `l2`; autotune can compare `max`, `mean`, and `l2`;
+- `groupby` creates a separate multivariate model per label combination and must be frozen/domain-
+  selected rather than optimized;
+- `recommended_max_channels=100` is advisory; `max_channels=1000` is a hard safety limit;
+- explicitly requesting channel-level `y`/forecasts/bounds increases output cardinality.
+
+## Simple online models
+
+### `mad_online`
+
+Use for robust point anomalies on simple, non-seasonal, relatively stable metrics. It tolerates
+outliers and has very low operational cost, but does not explicitly model trend/calendar patterns.
+
+### `zscore_online`
+
+Use when the profile is stable/light-tailed and standard-deviation magnitude is meaningful. It is
+simple and explainable but more outlier-sensitive than MAD.
+
+### `quantile_online`
+
+Use for seasonal quantile behavior with absent or slow trend. It requires enough observations in
+each seasonal bucket and is not a general trend model.
+
+For stable MAD, Z-score, and online-quantile distributions, use `history_strength > 1` (typically
+`2`–`3`) to reduce the leverage of new observations without fitting many extra historical cycles.
+This can reduce fit-time data, CPU, and RAM, but it does not replace coverage of every required
+seasonal phase and should not anchor a genuinely changing regime.
+
+## Offline and specialized alternatives
+
+### `prophet`
+
+Deprioritize Prophet: vmanomaly cannot currently pass external regressors through its API, while
+Temporal Envelope covers the supported online trend/calendar/holiday use cases. Keep Prophet only
+for legacy or comparative configurations that demonstrably perform better. For `step < 1h`, use
+frozen compression such as:
+
+```yaml
+compression:
+  window: 1h
+  agg_method: mean
+  adjust_boundaries: true
+```
+
+Preserve the final inference step. Use a smaller compression window only when sub-hour patterns
+matter.
+
+### `holtwinters`
+
+Deprioritize Holt-Winters in new configurations. Prefer an online model unless comparative
+validation establishes a clear benefit.
+
+### Isolation Forest
+
+Deprioritize Isolation Forest in new configurations. It does not extrapolate a temporal forecast
+and must be periodically refitted; retain it only when feature-space anomaly validation clearly
+outperforms the corresponding online model.
+
+## Fit-window and cadence guidance
+
+| Profile | Minimum history | Preferred starting history |
+|---|---:|---:|
+| HOD/daily | `2d` | `7d` |
+| DOW/weekly | `2w` | `30d` |
+| month-of-year | `24mo` when feasible | `24mo+` |
+
+Use the longest required history for multiple profiles. Explain when available history is shorter.
+Partial fit history can still be useful for online models, but cold-start/warmup remains visible.
+
+For online models, default `fit_every` to an effectively disabled cadence such as `1000w`: perform
+one initial fit, then improve state causally during inference. Configure periodic refits only when
+the user explicitly needs resets or relearning. Offline models require periodic refits, which is
+another reason to deprioritize them.
+
+## Autotune guidance
+
+- Autotune a selected model; v1.30 shared autotune does not choose a class.
+- `anomaly_percentage` is an upper detection-volume constraint, not a target count.
+- Use `exact:true` for online validation to match causal production inference.
+- Keep business facts frozen: known direction, data bounds, holidays, `groupby`, and mandatory
+  thresholds.
+- Optimize complexity when comparable candidates exist so simpler fitted state wins ties.
+- Apply and validate returned `result_data.data.modelConfig`.
+- Deploy `class: auto` only when refit-time retuning is explicitly desired.

--- a/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: vmanomaly-query
+description: >
+  Operate VictoriaMetrics Anomaly Detection (vmanomaly) through its HTTP API. Use when checking
+  health, versions, persisted-state compatibility, self-monitoring metrics, available models,
+  model schemas, server queries, time-series characteristics, shared autotune, or asynchronous
+  detection tasks. Also use for generating and validating vmanomaly configuration or alert-rule
+  YAML. Triggers on vmanomaly API, anomaly tasks, model validation, model schema, compatibility,
+  Temporal Envelope, time-series profiling, and vmanomaly autotune.
+allowed-tools: Bash(curl:*), Bash(jq:*)
+---
+
+# vmanomaly API
+
+Operate a running vmanomaly v1.30+ instance through bounded, explicit API calls. Prefer live
+schemas and server responses over static assumptions.
+
+## Environment and authentication
+
+```bash
+# Include any configured path prefix in the base URL.
+export VM_ANOMALY_URL="https://vmanomaly.example.com"
+# Use /dev/null for unauthenticated local instances. For authenticated instances, point this to
+# a mode-0600 curl config containing: header = "Authorization: Bearer <token>"
+export VM_CURL_CONFIG="${VM_CURL_CONFIG:-/dev/null}"
+```
+
+Keep credentials out of process arguments and use the same config for every request:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/health" | jq .
+```
+
+Never print or create the credential file. Ask for `VM_ANOMALY_URL` when it is unset.
+
+## Start with a runtime preflight
+
+Run these checks before configuration, review, autotune, or migration work:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/health" | jq .
+
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/server/buildinfo" | jq .
+
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/compatibility" | jq .
+```
+
+Interpret compatibility conservatively:
+
+- `global_check.has_state=false`: no persisted state needs migration.
+- `global_check.is_compatible=true`: the checked state can be reused.
+- `global_check.drop_everything=true`: report that all persisted state must be dropped; do not
+  perform the drop automatically.
+- `component_assessment.models_to_purge` or `should_purge_reader_data`: report the scoped cleanup.
+- Use `?version_to=X.Y.Z` to assess the stored state against a planned target release.
+
+Only GET compatibility is implemented. Do not invent a POST endpoint for arbitrary provided
+configs. For configuration syntax, use `/api/v1/config/validate` instead.
+
+## Discover capabilities before using them
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/models" | jq .
+
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode 'model_class=temporal_envelope' \
+  "$VM_ANOMALY_URL/api/v1/model/schema" | jq .
+```
+
+Treat `/api/v1/models` and `/api/v1/model/schema` as authoritative. Do not carry parameters
+between model classes unless the target schema exposes them.
+
+## Validate before running
+
+Validate one model:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' \
+  -d '{"class":"temporal_envelope","seasonalities":["hod_smooth","dow_smooth"]}' \
+  "$VM_ANOMALY_URL/api/v1/model/validate" | jq .
+```
+
+Validate a complete configuration:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/yaml' \
+  --data-binary @config.yaml \
+  "$VM_ANOMALY_URL/api/v1/config/validate" | jq .
+```
+
+Validation does not apply or reload a configuration.
+
+## Inspect the running server
+
+```bash
+# Configured query aliases and expressions.
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/server/queries" | jq .
+
+# Configured datasource context. Keep only documented fields and redact URL user information.
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/server/datasource" | jq '
+    with_entries(select(.key | IN("server_datasource_url", "ui_datasource_url", "ui_datasource_type")))
+    | with_entries(
+        if (.value | type) == "string" and (.key | endswith("_url"))
+        then .value |= sub("://[^/@]+@"; "://<redacted>@")
+        else .
+        end
+      )'
+
+# Prometheus-format self-monitoring metrics.
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/metrics?name[]=vmanomaly_scheduler_alive&name[]=vmanomaly_scheduler_restarts_total&name[]=vmanomaly_model_run_errors&name[]=vmanomaly_model_runs_skipped"
+```
+
+Treat `/health` as a point-in-time preflight, not production monitoring. For a running deployment,
+recommend scraping or pushing the documented
+[self-monitoring metrics](https://docs.victoriametrics.com/anomaly-detection/components/monitoring/#metrics-generated-by-vmanomaly),
+installing the [Grafana dashboard](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#grafana-dashboard),
+and reviewing the supplied [alerting rules](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#alerting-rules).
+Prioritize service availability, scheduler liveness/restarts, reload failures, model errors/skips,
+I/O error rates, and resource pressure. Do not deploy rules or dashboards without user approval.
+
+When installed, use `victoriametrics-query` to verify that self-monitoring series are ingested and
+the expected rules are loaded; use `alertmanager-query` to inspect active, silenced, or inhibited
+vmanomaly alerts.
+
+## Profile a query before choosing a model
+
+An exact non-empty query is required. If the user supplied one, reuse it. Otherwise resolve a
+configured query alias or ask the user; never invent a production query from a metric description.
+
+```bash
+QUERY='sum(rate(http_requests_total{job="api"}[5m])) by (service)'
+TIMEZONE='America/New_York'
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode "query=$QUERY" \
+  --data-urlencode 'start=<unix-seconds>' \
+  --data-urlencode 'end=<unix-seconds>' \
+  --data-urlencode 'step=5m' \
+  --data-urlencode "timezone=$TIMEZONE" \
+  --data-urlencode 'limit=100' \
+  "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
+```
+
+Use the same `step` for profiling, autotune, and the final task/config. Treat a limited response
+as a sample, not an exact population summary. If a limited read returns a split-chunk `422`, use
+a shorter interval or coarser step.
+
+## Run shared autotune
+
+Choose `tuned_class_name` first from the profile, business intent, `/api/v1/models`, and schema.
+Shared v1.30 autotune does not choose the model class.
+
+```bash
+jq -n --arg query "$QUERY" --arg timezone "$TIMEZONE" '{
+    query:$query,
+    "tuned_class_name":"temporal_envelope",
+    "anomaly_percentage":0.02,
+    "start":1710000000,
+    "end":1711209600,
+    "step":"5m",
+    timezone:$timezone,
+    "limit":100,
+    "use_profile_hints":true,
+    "optimization_params":{"n_trials":64,"timeout":30,"exact":true,"optimize_complexity":true},
+    "frozen_params":{"detection_direction":"above_expected"}
+  }' | curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' --data-binary @- \
+  "$VM_ANOMALY_URL/api/v1/autotune/tasks" | jq .
+```
+
+Tell the user the trial/time budget before creating the task. Poll one task sequentially:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/autotune/tasks/<task_id>" | jq .
+```
+
+Treat `done`, `error`, and `canceled` as terminal. On `done`, apply
+`result_data.data.modelConfig` directly, validate it, and test it. Do not replace this concrete
+one-time recommendation with `class: auto`; the deployable auto wrapper has a different lifecycle.
+Use DELETE only when the user asks to cancel:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X DELETE "$VM_ANOMALY_URL/api/v1/autotune/tasks/<task_id>" | jq .
+```
+
+## Run bounded detection tasks
+
+Check capacity first:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
+```
+
+Create a task only after validating `model_spec`:
+
+```bash
+jq -n --arg query "$QUERY" '{
+    query:$query,
+    "step":"5m",
+    "fit_window":"30d",
+    "fit_every":"1000d",
+    "start_infer_s":1710000000,
+    "end_infer_s":1710086400,
+    "exact":true,
+    "model_spec":{"class":"temporal_envelope","seasonalities":["hod_smooth","dow_smooth"]}
+  }' | curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' --data-binary @- \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks" | jq .
+```
+
+Use `exact:true` for causal online-model evaluation. Poll sequentially and never create duplicate
+tasks merely because a task is still running.
+
+## Generate deployment artifacts
+
+Use `/api/vmanomaly/config.yaml` for an example configuration and
+`/api/vmanomaly/example-alert-rule.yaml` for a VMAlert rule. Pass values with `--data-urlencode`.
+Validate the resulting configuration before presenting it as ready to deploy.
+
+## Optional companion skills
+
+- Use `victoriametrics-query` when available to discover metric names, labels, cardinality, or
+  existing alert/rule queries before constructing PromQL/MetricsQL.
+- Use `victorialogs-query` when the datasource is VictoriaLogs and LogsQL discovery is needed.
+- Use `alertmanager-query` to check active alerts or avoid duplicating existing alerting intent.
+
+These are optional enhancements. Continue through vmanomaly server/proxy endpoints when they are
+not installed.
+
+## Reference
+
+Read `references/api-reference.md` for endpoint parameters, response fields, error handling, and
+v1.30 task semantics.

--- a/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
@@ -1,0 +1,241 @@
+# vmanomaly v1.30 API reference
+
+This reference covers the stable workflows used by the vmanomaly skills. The running OpenAPI
+document and model schemas remain authoritative.
+
+## Contents
+
+- [Common conventions](#common-conventions)
+- [Runtime and compatibility](#runtime-and-compatibility)
+- [Models and configuration](#models-and-configuration)
+- [Server context and query proxy](#server-context-and-query-proxy)
+- [Time-series characteristics](#time-series-characteristics)
+- [Shared autotune](#shared-autotune)
+- [Detection tasks](#detection-tasks)
+- [Errors and safe retries](#errors-and-safe-retries)
+
+## Common conventions
+
+Base URL: `$VM_ANOMALY_URL`. Include `path_prefix` in this value when configured.
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Process health |
+| `/metrics` | GET | Prometheus self-monitoring metrics |
+| `/api/v1/server/buildinfo` | GET | Runtime and bundled UI versions |
+| `/api/v1/compatibility` | GET | Stored-state compatibility |
+| `/api/v1/models` | GET | Available model aliases |
+| `/api/v1/model/schema` | GET | Model JSON schema |
+| `/api/v1/model/validate` | POST | Validate one model spec |
+| `/api/v1/config/validate` | POST | Validate full YAML configuration |
+| `/api/v1/server/queries` | GET | Configured query aliases |
+| `/api/v1/server/datasource` | GET | Configured datasource context |
+| `/api/v1/query` | GET/POST | Proxy a datasource query |
+| `/api/v1/timeseries/characteristics` | GET | Profile a bounded query sample |
+| `/api/v1/autotune/tasks` | POST | Start shared autotune |
+| `/api/v1/autotune/tasks/{id}` | GET/DELETE | Poll/cancel autotune |
+| `/api/v1/anomaly_detection/limits` | GET | Detection-task capacity |
+| `/api/v1/anomaly_detection/tasks` | POST/GET | Create/list detection tasks |
+| `/api/v1/anomaly_detection/tasks/{id}` | GET/DELETE | Poll/cancel detection |
+| `/api/vmanomaly/config.yaml` | GET | Generate example configuration |
+| `/api/vmanomaly/example-alert-rule.yaml` | GET | Generate VMAlert rule |
+
+Use JSON request bodies unless an endpoint explicitly accepts YAML or query parameters.
+Times may be Unix seconds; durations use strings such as `5m`, `2w`, or `30d`.
+
+`/health` is a point check. Production health should use the documented `/metrics` series together
+with the official vmanomaly self-monitoring dashboard and alert rules, including scheduler-level
+`vmanomaly_scheduler_alive` and `vmanomaly_scheduler_restarts_total` signals.
+
+## Runtime and compatibility
+
+### `GET /api/v1/server/buildinfo`
+
+Returns the vmanomaly and bundled VMUI versions. Use it to establish runtime capabilities before
+assuming a model or endpoint exists.
+
+### `GET /api/v1/compatibility`
+
+Checks persisted configuration/model/reader state against the current runtime. Optional query
+parameter `version_to=X.Y.Z` checks a planned target instead.
+
+Important response fields:
+
+- `runtime_version`, `stored_version`
+- `global_check.has_state`
+- `global_check.is_compatible`
+- `global_check.reason`
+- `global_check.drop_everything`
+- `component_assessment.models_to_purge`
+- `component_assessment.should_purge_reader_data`
+
+No state is a successful result, not an error. The endpoint diagnoses required cleanup but does
+not perform it. The provided-config POST variant is not implemented in v1.30.
+
+## Models and configuration
+
+### `GET /api/v1/models`
+
+Returns aliases supported by this build. Common v1.30 values include `temporal_envelope`,
+`temporal_envelope_multivariate`, `mad_online`, `zscore_online`, `quantile_online`, `prophet`,
+`holtwinters`, and Isolation Forest variants. Never replace the returned list with a hardcoded one.
+
+### `GET /api/v1/model/schema?model_class=<alias>`
+
+Returns parameter types, bounds, defaults, descriptions, and allowed values. Use the schema as an
+allow-list whenever changing model class. Internal attachment/output fields may not appear in the
+UI-oriented schema.
+
+### `POST /api/v1/model/validate`
+
+Accepts one JSON model spec containing `class`. A 201 response is successful. A 422 response
+contains validation details; correct the spec rather than silently dropping user requirements.
+
+### `POST /api/v1/config/validate`
+
+Validates a full configuration without applying it. Send YAML with `Content-Type:
+application/yaml`. Runtime deployment or hot reload is a separate user-controlled action.
+
+### Generated artifacts
+
+`GET /api/vmanomaly/config.yaml` accepts model/query/scheduler parameters and returns YAML.
+`GET /api/vmanomaly/example-alert-rule.yaml` returns a VMAlert rule. Use `--data-urlencode` for
+expressions and durations. Generated output still needs validation and human review.
+
+## Server context and query proxy
+
+### `GET /api/v1/server/queries`
+
+Returns configured query aliases and expressions. Resolve aliases here before asking the user to
+repeat an already configured query.
+
+### `GET /api/v1/server/datasource`
+
+Returns the configured server/UI datasource URLs and type. Do not expose credentials.
+
+### `GET|POST /api/v1/query`
+
+Proxies PromQL/MetricsQL or LogsQL through the configured reader path. Typical parameters:
+
+- `query` (required)
+- `start`, `end`, `step`
+- `datasource_type` (`vm` or `vlogs`)
+- optional `datasource_url`, `tenant_id`, `pass_auth_headers`
+
+Use the product-specific companion query skill for discovery when installed. A successful empty
+result does not prove that no data exists; first verify the query and label names.
+
+## Time-series characteristics
+
+### `GET /api/v1/timeseries/characteristics`
+
+Profiles a bounded sample before model selection or autotune.
+
+Parameters:
+
+- `query` (required, non-empty)
+- `start`, `end`
+- `step` (use the final inference resolution)
+- `datasource_type`, optional datasource override and tenant
+- `timezone` for local-calendar analysis
+- `short_gap_steps`
+- `limit` (default 100)
+- `verbose` for extra aggregate diagnostics without identifiers
+
+Key response evidence:
+
+- `eligible_series_count`, `eligible_series_share`, `coverage_threshold`
+- `has_trend`, `trend.share`, `trend.direction_mode`
+- `has_daily`, `has_weekly`, `has_monthly`
+- `shape.flat_share`, `spiky_share`, `intermittent_share`
+- `seasonalities.recommended` and per-profile summaries
+- `stats.seriesLimitApplied`, `seriesEstimated`, `seriesLimitMode`
+
+Interpret HOD/hour-of-day as a daily local-hour pattern and DOW/day-of-week as a weekly pattern.
+Limited results are directional samples. Limited reads must fit one query chunk; on a split-chunk
+422, shorten the interval or use a coarser step.
+
+## Shared autotune
+
+### `POST /api/v1/autotune/tasks`
+
+Tunes one already selected model class across a bounded query sample. Required conceptual inputs:
+
+- exact `query`
+- `tuned_class_name`
+- expected upper alert-volume constraint `anomaly_percentage`
+- `start`, `end`, `step`
+- explicit optimization budget
+
+Useful controls:
+
+- `limit`
+- `use_profile_hints`
+- `optimization_params.n_trials`, `timeout`
+- `optimization_params.exact` for causal online-model evaluation
+- `optimization_params.optimize_complexity` for fitted-state tie-breaking
+- `optimized_business_params` only for business fields the user authorizes tuning
+- `frozen_params` for fixed domain/model choices such as direction, holidays, or multivariate
+  `groupby`
+
+For sub-hour Prophet tuning, freeze compression when appropriate while preserving the final query
+step. For multivariate models, keep group structure fixed rather than treating it as an optimizer
+dimension.
+
+Creation returns a task ID immediately. Poll `GET /api/v1/autotune/tasks/{id}` until `done`,
+`error`, or `canceled`.
+
+On `done`, use:
+
+- `result_data.data.modelConfig`: validated candidate to apply/test
+- `result_data.data.bestParams`, `bestScore`
+- `result_data.data.profile`
+- `result_data.data.optimization`
+- `result_data.stats`
+
+This workflow returns a concrete one-time recommendation. It is different from deploying
+`class: auto`, which retunes during the model fitting lifecycle.
+
+There is no v1.30 autotune task-list or limits endpoint. Do not invent them.
+
+## Detection tasks
+
+### `GET /api/v1/anomaly_detection/limits`
+
+Check available capacity before creating a task. A 429 from task creation means capacity is
+exhausted; wait or ask before canceling other work.
+
+### `POST /api/v1/anomaly_detection/tasks`
+
+Important fields:
+
+- `query`, `step`, `datasource_url` when not resolved from server context
+- `fit_window`, `fit_every`
+- `start_infer_s`, `end_infer_s`
+- validated `model_spec`
+- `exact` and `infer_every` where applicable
+
+For UI/API exploration with an online model, a very large `fit_every` can intentionally preserve
+one causal state through the displayed interval. Production periodic cadence is a separate choice.
+
+Task results can contain `y`, `yhat`, bounds, and anomaly score depending on model output. The API
+may constrain output fields for response size; do not copy that response-oriented `provide_series`
+setting into production without an explicit reason.
+
+### Polling and cancellation
+
+Poll one task every few seconds. Treat `done`, `error`, and `canceled` as terminal. Use DELETE for
+cooperative cancellation only when requested. Never create duplicate tasks to simulate polling.
+
+## Errors and safe retries
+
+| Status | Meaning | Response |
+|---|---|---|
+| 400 | malformed/unsupported request | Correct the request; do not retry blindly |
+| 404 | unknown route/task/model | Recheck build info, path prefix, alias, or task ID |
+| 422 | validation/query error | Read details; correct fields or query window |
+| 429 | task capacity reached | Wait, reduce concurrency, or ask before cancellation |
+| 500 | server/runtime failure | Preserve error details and inspect logs/metrics |
+
+Retry only transient connection/server failures, with a bounded count. Validation failures are not
+transient. Keep tool calls sequential when later calls depend on IDs or results from earlier ones.

--- a/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: vmanomaly-review
+description: >
+  Audit an existing VictoriaMetrics vmanomaly configuration against runtime capabilities and
+  real data. Use when reviewing model-data fit, scheduler cadence, persisted-state compatibility,
+  cold start, excessive detections, missing anomalies, output cardinality, or upgrade readiness.
+  Trigger on vmanomaly config review, false-positive investigation, detection quality, model
+  effectiveness, compatibility, and "is my anomaly detection working?" Use vmanomaly-config
+  instead when building a new configuration from scratch.
+allowed-tools: Bash(curl:*), Bash(jq:*), Read
+---
+
+# vmanomaly configuration reviewer
+
+Review a running or proposed vmanomaly v1.30+ configuration without mutating it. Separate facts,
+measured evidence, and hypotheses. A static rule may be a better outcome than an ML model.
+
+Read `references/evaluation-guide.md` before judging detections or model-data fit.
+
+## Environment
+
+```bash
+export VM_ANOMALY_URL="https://vmanomaly.example.com"
+# Use /dev/null without authentication. For authenticated instances, point this to a mode-0600
+# curl config containing: header = "Authorization: Bearer <token>"
+export VM_CURL_CONFIG="${VM_CURL_CONFIG:-/dev/null}"
+```
+
+Include any path prefix in the base URL. Never print or create the credential file.
+
+## Workflow
+
+### 1. Load and summarize the configuration
+
+Read the YAML path supplied by the user, including `configRawYaml` embedded in a Kubernetes
+resource. Summarize:
+
+- query aliases and expressions;
+- model aliases/classes, parameters, queries, and schedulers;
+- scheduler `infer_every`, `fit_every`, and `fit_window`;
+- datasource type and relevant reader settings;
+- expected reaction time and anomaly intent if known.
+
+Group queries by model so shared parameters and multivariate relationships are visible. Ask for an
+exact missing query; do not invent one.
+
+### 2. Run compatibility and capability preflight
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/health" | jq .
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/server/buildinfo" | jq .
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/compatibility" | jq .
+```
+
+Report incompatibility and scoped cleanup; do not execute cleanup. No stored state is healthy.
+Use `?version_to=X.Y.Z` when reviewing an upgrade. Only GET exists in v1.30.
+
+For deployed instances, also verify that self-monitoring metrics are collected and that the
+official dashboard and alerting rules cover service health, scheduler liveness/restarts, reload
+failures, model errors/skips, I/O failures, and resource pressure. A successful `/health` response
+alone is insufficient production evidence.
+
+Discover runtime aliases and fetch the schema for every configured class:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/models" | jq .
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode 'model_class=<alias>' \
+  "$VM_ANOMALY_URL/api/v1/model/schema" | jq .
+```
+
+### 3. Perform static validation
+
+Validate the full YAML:
+
+```bash
+CONFIG_PATH='<user-supplied-yaml-path>'
+curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/yaml' --data-binary "@$CONFIG_PATH" \
+  "$VM_ANOMALY_URL/api/v1/config/validate" | jq .
+```
+
+Also inspect:
+
+- every query/model/scheduler reference resolves and no important component is orphaned;
+- every model parameter exists in that exact class schema; use full-config validation for reader,
+  scheduler, writer, and top-level fields;
+- `infer_every` meets the user's reaction-time requirement;
+- fit history covers configured calendar cycles;
+- known data bounds and significance thresholds match query units;
+- `min_n_samples_seen` can complete within available history;
+- multivariate `groupby` and channel counts match the intended dependency groups;
+- requested `provide_series` does not create accidental output cardinality;
+- offline models have a suitable refit cadence.
+
+Changing class requires reconstructing the spec from the new schema, not deleting errors one by
+one until validation passes.
+
+### 4. Re-triage each signal
+
+Flag metrics where static alerting is clearer: hard limits, expiry, binary state, monotonic fill,
+or near-zero failures. Avoid duplicating a precise static alert with a less interpretable model.
+
+Keep ML for natural variance, differing per-series baselines, trend/calendar behavior, persistent
+shifts, or cross-series dependency anomalies.
+
+### 5. Profile each exact query
+
+Use the configured query step and timezone, and a history window long enough for claimed
+seasonality:
+
+```bash
+QUERY='<exact-query>'
+TIMEZONE='<configured-IANA-timezone>'
+curl -q --config "$VM_CURL_CONFIG" -sG \
+  --data-urlencode "query=$QUERY" \
+  --data-urlencode 'start=<unix-seconds>' \
+  --data-urlencode 'end=<unix-seconds>' \
+  --data-urlencode 'step=<configured-step>' \
+  --data-urlencode "timezone=$TIMEZONE" \
+  --data-urlencode 'limit=100' \
+  "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
+```
+
+Compare measured trend, profile shape, seasonalities, eligible share, coverage, and series count
+with the configured class and profiles. Limited results are samples. Do not extrapolate exact
+population counts from them.
+
+Model-fit expectations:
+
+- complex trend/calendar/holiday/shift profile: `temporal_envelope` is the preferred first check;
+- simple non-seasonal heavy-tailed profile: `mad_online`;
+- stable/light-tailed simple profile: `zscore_online`;
+- dependency anomaly: `temporal_envelope_multivariate`, with Isolation Forest as an offline
+  feature-space alternative;
+- Prophet is a fallback for its specific regressors/decomposition or when validation favors it.
+
+### 6. Reproduce with a bounded task
+
+Check capacity, then create one bounded task with the exact validated model specification:
+
+```bash
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
+
+MODEL_SPEC_JSON='<validated-model-json>'
+STEP='<configured-step>'
+FIT_WINDOW='<configured-fit-window>'
+FIT_EVERY='<exploratory-fit-cadence>'
+START_INFER_S='<unix-seconds>'
+END_INFER_S='<unix-seconds>'
+jq -n \
+  --arg query "$QUERY" \
+  --arg step "$STEP" \
+  --arg fit_window "$FIT_WINDOW" \
+  --arg fit_every "$FIT_EVERY" \
+  --argjson start_infer_s "$START_INFER_S" \
+  --argjson end_infer_s "$END_INFER_S" \
+  --argjson model "$MODEL_SPEC_JSON" '{
+    query:$query,
+    step:$step,
+    fit_window:$fit_window,
+    fit_every:$fit_every,
+    start_infer_s:$start_infer_s,
+    end_infer_s:$end_infer_s,
+    exact:true,
+    model_spec:$model
+  }' | curl -q --config "$VM_CURL_CONFIG" -s \
+  -X POST -H 'Content-Type: application/json' --data-binary @- \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks" | jq .
+
+curl -q --config "$VM_CURL_CONFIG" -s \
+  "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks/<task_id>" | jq .
+```
+
+Poll sequentially until `done`, `error`, or `canceled`. Use `exact:true` for causal online-model
+evaluation. Keep query step, timezone, direction, data bounds, and significance thresholds aligned
+with production.
+
+For an exploratory online task, a `fit_every` longer than the inference range preserves a single
+continuous state. This is not automatically the right production cadence.
+
+Do not create duplicates while a task is running. Task creation and config validation are read-only
+with respect to deployment; applying changes is not.
+
+### 7. Evaluate evidence correctly
+
+Without labels or user-confirmed events:
+
+- report **detection rate**, never claim a false-positive rate;
+- inspect representative detections across time and labelsets;
+- ask the user which were useful, expected events, or noise;
+- check cold-start, seasonal boundaries, missing data, and regime transitions separately.
+
+With labels, report precision, recall, F1, detection delay, and settled-regime false positives as
+appropriate. Prefer forward/causal validation for online models.
+
+### 8. Prove proposed fixes
+
+Change the smallest justified set, validate it, and rerun the same bounded interval. Compare:
+
+- useful detections and missed confirmed events;
+- detection rate or labeled precision/recall;
+- forecast/boundary behavior when supported;
+- warmup and adaptation delay;
+- compute/state/output-cardinality impact.
+
+Typical fixes include removing unsupported seasonal profiles, widening/narrowing the ordinary
+envelope, freezing direction/domain thresholds, extending fit history, splitting heterogeneous
+queries, adding multivariate grouping, or choosing a simpler/static detector.
+
+Shared autotune may produce a candidate after model class is chosen. Use `exact:true` for online
+models and apply the returned concrete `modelConfig`; do not silently convert it to `class: auto`.
+
+### 9. Report
+
+For each query/model provide:
+
+- verdict: pass, needs change, or replace with static rule;
+- evidence from schema, compatibility, profile, and bounded test;
+- severity and operational consequence;
+- minimal proposed change and before/after result;
+- assumptions, confidence, and follow-up observation window.
+
+Separate confirmed faults from hypotheses. A visually unusual point is not automatically an
+anomaly, and an empty query result is not automatically proof of missing data.
+
+## Optional companion skills
+
+- `victoriametrics-query`: verify PromQL/MetricsQL, self-monitoring ingestion, labels, cardinality,
+  and loaded vmanomaly alert rules.
+- `victorialogs-query`: validate LogsQL and correlate log behavior.
+- `alertmanager-query`: inspect active, silenced, or inhibited vmanomaly alerts before declaring
+  service health or duplicated intent.
+- `investigating-with-observability`: correlate confirmed detection windows with logs/traces.
+- cardinality-analysis skills: assess excessive series/output fan-out.
+
+These integrations improve evidence but are not prerequisites; continue using vmanomaly proxy and
+server endpoints when they are absent.
+
+## Safety
+
+- Do not apply configs, create persistent rules, purge state, or cancel another user's task without
+  explicit approval.
+- Bound time windows, series limits, and task concurrency.
+- Preserve exact queries, timestamps, and errors in the report, but redact credentials.

--- a/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
@@ -1,0 +1,151 @@
+# vmanomaly review and evaluation reference
+
+This guide defines consistent evidence and avoids overstating unlabeled results.
+
+## Contents
+
+- [Evidence levels](#evidence-levels)
+- [Static checks](#static-checks)
+- [Model-data fit](#model-data-fit)
+- [Detection evaluation](#detection-evaluation)
+- [Common failure patterns](#common-failure-patterns)
+- [Report template](#report-template)
+
+## Evidence levels
+
+1. **Runtime fact:** health, build info, compatibility response, live schema, validation error.
+2. **Measured profile:** characteristics over a stated query/window/step/sample limit.
+3. **Bounded experiment:** repeatable task result using stated model and interval.
+4. **User-confirmed truth:** known incident, expected event, or reviewed detection.
+5. **Hypothesis:** plausible explanation requiring another test.
+
+Do not present levels 2–3 as labeled ground truth.
+
+## Static checks
+
+### Deployment readiness
+
+- Online periodic models should restore compatible state from durable on-disk storage.
+- High-churn inputs should use a retention TTL longer than legitimate series absence, with a check
+  interval shorter than both TTL and the smallest `fit_every`.
+- Hot reload should be content-polled, preceded by full-config validation, and covered by reload
+  success metrics.
+- Scatter inference only for many queries and measured synchronized load; match workers to actual
+  CPU limits.
+- Recommend sharding/replication only for measured capacity or availability requirements, and
+  require output deduplication with replicated writers.
+
+### Scheduler timing
+
+- `infer_every` bounds how long a new point may wait for the next scheduled inference.
+- `fit_window` must contain enough cycles for configured seasonality.
+- `fit_every` controls refitting, not the online update cadence.
+- A long `fit_every` is valid for an exploratory exact online task that should preserve one state;
+  it is not a universal production recommendation.
+
+Starting history guidance:
+
+| Pattern | Minimum | Preferred |
+|---|---:|---:|
+| daily/HOD | `2d` | `7d` |
+| weekly/DOW | `2w` | `30d` |
+| month-of-year | `24mo` when feasible | `24mo+` |
+
+Partial fit history can initialize online models, but warmup and weaker seasonal estimates should
+be stated. Completely empty fit history requires causal cold-start and delays trusted scores.
+
+### Cross references
+
+- Every model query and scheduler alias resolves.
+- Every model parameter exists in its exact class schema. Validate reader, scheduler, writer, and
+  other top-level fields and cross-references with full-configuration validation.
+- Multivariate groups contain aligned, semantically related channels.
+- The writer can safely absorb requested output cardinality.
+
+## Model-data fit
+
+| Measured evidence | First candidate |
+|---|---|
+| simple, no strong trend/calendar pattern, robust baseline needed | `mad_online` |
+| simple stable/light-tailed data | `zscore_online` |
+| trend, several calendar profiles, holidays, or persistent shifts | `temporal_envelope` |
+| normality is a changing relationship between aligned channels | `temporal_envelope_multivariate` |
+| custom regressors or Prophet decomposition required | `prophet` |
+| generic feature-space outlier across aligned series | `isolation_forest_multivariate` |
+| generic feature-space outlier within one series | `isolation_forest_univariate` |
+
+Temporal Envelope profile names are shape hypotheses, not knobs to enable indiscriminately:
+
+- smooth: gradual recurring curve;
+- spiky: narrow recurring peaks;
+- plateau: sustained phase levels.
+
+Use the configured timezone for civil-time seasonality and DST correctness.
+
+## Detection evaluation
+
+### Unlabeled data
+
+Report:
+
+- detection rate = detected points / eligible scored points;
+- count and duration of detection windows;
+- labelsets affected and concentration across them;
+- representative plots/windows;
+- warmup and missing-data exclusions.
+
+Do not call detections false positives until a human or labels establish they are normal.
+
+### Labeled or user-confirmed data
+
+Report metrics appropriate to the event:
+
+- precision, recall, and F1 for detection utility;
+- detection delay for persistent changes;
+- time to stable and settled-regime false-positive rate for adaptation;
+- forecast/boundary error only for models that produce those outputs.
+
+Evaluate online models causally. Batch inference can leak future observations into validation and
+select parameters that underperform in production exact inference.
+
+### Comparison discipline
+
+Keep query, step, timezone, fit/inference windows, direction, business thresholds, and labels fixed.
+Change one coherent configuration at a time. Record task/model specifications with results.
+
+## Common failure patterns
+
+| Symptom | Check first | Possible response |
+|---|---|---|
+| many early detections | warmup, fit coverage, missing prior history | raise justified warmup or extend history |
+| recurring false-looking peaks | wrong/missing calendar profile, event contamination | correct profile; use robust Temporal Envelope |
+| persistent detections after shift | changepoint confirmation and trend reactivity | test window/reactivity, preserve anomaly-burst resistance |
+| misses small meaningful changes | business deadbands, interval width, direction | correct units; tune justified fields |
+| high detection volume everywhere | wrong data range, narrow boundaries, mismatched model | fix domain values; compare simpler/better-fit class |
+| multivariate score dominated by noise | grouping, channel semantics, aggregation | regroup, reduce channels, compare `l2`/`mean` |
+| UI task appears empty | datasource interval, fit history, warmup, output selection | inspect task error/result; do not assume model failure |
+| upgrade fails to load state | compatibility response | follow scoped purge guidance with approval |
+
+## Report template
+
+```markdown
+## Summary
+- Runtime/version:
+- Compatibility:
+- Scope and query window:
+- Overall verdict:
+
+## Findings
+### <severity>: <title>
+- Evidence:
+- Impact:
+- Proposed minimal change:
+- Verification:
+
+## Per-model results
+| Model/query | Profile fit | Detection evidence | Verdict |
+|---|---|---|---|
+
+## Assumptions and follow-up
+- ...
+```


### PR DESCRIPTION
## What this adds

- a `vmanomaly` marketplace plugin with three independently installable skills:
  - `vmanomaly-query` for v1.30+ API operation, compatibility checks, live schemas, profiling, autotune, and bounded detection tasks;
  - `vmanomaly-config` for static-vs-ML triage, evidence-based model selection, tuning, validation, and deployment artifacts;
  - `vmanomaly-review` for compatibility/config audits, real-data model-fit review, causal reproduction, and fix verification;
- concise per-skill references that are copied with individual skills.sh installations;
- README and Claude Code marketplace discovery/install documentation.

## Design choices

- Each skill is self-contained: no hard references to sibling skills, so `npx skills add ... --skill <name>` works independently.
- `allowed-tools` follows **least privilege**: `curl`/`jq`, plus `Read` only for skills that inspect local configuration.
- Running `/api/v1/models` and `/api/v1/model/schema` responses remain authoritative instead of hardcoding a release-specific model surface.
- Health, build information, and persisted-state compatibility are explicit preflight steps.
- Temporal Envelope is the preferred online model for complex temporal profiles; MAD/Z-score remain the simpler choices for non-seasonal data, with offline models used **only** when their distinct capabilities are required.
- Shared asynchronous autotune is distinguished from deployable `class: auto`: the shared endpoint returns a concrete `modelConfig` to validate and test.
- **Optional integration** with existing skills—`victoriametrics-query`/`victorialogs-query` for signal discovery, `alertmanager-query` for existing-alert review, and diagnostics skills such as `victoriametrics-cardinality-analysis` or `investigating-with-observability`—improves end-to-end workflows without adding installation dependencies.

## Validation

- all three `SKILL.md` files pass the skill-creator validator;
- all plugin/marketplace JSON parses with `jq`;
- `git diff --check` passes;
- `npx skills add . --list` discovers all three skills;
- a temporary `npx skills add ... --skill vmanomaly-query vmanomaly-config vmanomaly-review --copy` installation copied each skill and its private reference files successfully.
