### PR TITLE
all: sync list of allowed tools with actually used tools

### DIFF
--- a/plugins/diagnostics/skills/investigating-with-observability/SKILL.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: investigating-with-observability
 description: Use when investigating issues, debugging problems for applications, or responding to alerts in the Kubernetes cluster using VictoriaMetrics, VictoriaLogs, or VictoriaTraces.
-allowed-tools: Bash(curl:*), Agent, Read
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*), Agent, Read
 ---
 
 # Troubleshooting with Observability Skills
@@ -203,7 +203,7 @@ echo "ALERTMANAGER:${VM_ALERTMANAGER_URL:+available}"
    - Investigation context: target namespace, service name, time range (RFC3339)
    - Any specific queries or metrics to look for
 3. Dispatch independent subagents in the SAME tool-call message for parallel execution
-4. Set `allowed-tools: Bash(curl:*)` on each subagent
+4. Set `allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*)` on each subagent
 
 ### Agent Files
 

--- a/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
+++ b/plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: >
   series reduction, unused metrics, high cardinality labels, TSDB optimization, storage cost reduction,
   metric cleanup, too many time series, or wants to reduce cardinality. Also trigger when discussing
   relabeling strategies, streaming aggregation opportunities, or "which metrics can we drop".
-allowed-tools: Bash(curl:*), Bash(jq:*)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*)
 ---
 
 # VictoriaMetrics Cardinality Analysis

--- a/plugins/diagnostics/skills/vm-trace-analyzer/SKILL.md
+++ b/plugins/diagnostics/skills/vm-trace-analyzer/SKILL.md
@@ -14,6 +14,7 @@ description: >
   thorough analysis — do not attempt to analyze VM traces without it.
 argument-hint: trace.json
 disable-model-invocation: true
+allowed-tools: Bash(python3:*), Read
 ---
 
 # VictoriaMetrics Query Trace Analyzer

--- a/plugins/query/skills/alertmanager-query/SKILL.md
+++ b/plugins/query/skills/alertmanager-query/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Query AlertManager via curl using the v2 API. Use when listing active/silenced alerts, creating/managing silences,
   or checking alert inhibition state. Triggers on: alertmanager, silences, silence alerts, alert filters,
   alert inhibition, alertmanager API, create silence, delete silence.
-allowed-tools: Bash(curl:*)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*)
 ---
 
 # AlertManager Query (API v2)

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -5,7 +5,7 @@ description: >
   discovering log fields/streams, analyzing log hit patterns, or exploring log facets.
   Triggers on: log queries, LogsQL, log search, log stats, field discovery, stream discovery,
   log facets, log hits, log field values.
-allowed-tools: Bash(curl:*)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*)
 ---
 
 # VictoriaLogs Query

--- a/plugins/query/skills/victoriametrics-query/SKILL.md
+++ b/plugins/query/skills/victoriametrics-query/SKILL.md
@@ -6,7 +6,7 @@ description: >
   or debugging relabeling/downsampling/retention configs. Triggers on: metric queries, PromQL, MetricsQL,
   label discovery, series exploration, cardinality checks, alert status, recording rules, active/top queries,
   export data, metric statistics, relabel debug, downsampling debug, retention debug, flags.
-allowed-tools: Bash(curl:*)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(head:*)
 ---
 
 # VictoriaMetrics Metrics Query

--- a/plugins/query/skills/victoriatraces-query/SKILL.md
+++ b/plugins/query/skills/victoriatraces-query/SKILL.md
@@ -5,7 +5,7 @@ description: >
   and operations, searching traces by service/operation/duration/tags, retrieving traces by ID,
   or mapping service dependencies. Triggers on: trace queries, span search, trace ID lookup,
   service discovery, operation discovery, service dependencies, distributed tracing, Jaeger API.
-allowed-tools: Bash(curl:*)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(date:*)
 ---
 
 # VictoriaTraces Query


### PR DESCRIPTION
Currently, some tools are missing from allowed list which will force user to confirm agent actions. This is inconsistent and unexpected since curl was pre-allowed but results parsing requires approval.