### PR TITLE
Docs: favor online vmanomaly models

### DIFF
--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -123,14 +123,18 @@ never carry stale parameters across classes.
 
 Default hierarchy:
 
-1. For complex operational profiles with trend, calendar patterns, holidays, persistent shifts,
-   or forecasts, start with `temporal_envelope`.
-2. For simple non-seasonal data, prefer `mad_online`; use `zscore_online` when the distribution is
-   stable/light-tailed and standard-deviation magnitude is meaningful.
+1. Start with `temporal_envelope` for any non-trivial temporal profile: trend, calendar patterns,
+   holidays, persistent shifts, forecasts, or uncertainty about whether a simple stationary
+   baseline is sufficient.
+2. Use `mad_online` or `zscore_online` only when profiling confirms simple, non-seasonal,
+   relatively stable data. Prefer MAD for skewed, heavy-tailed, or outlier-contaminated data; use
+   Z-score only when the distribution is stable/light-tailed and standard-deviation magnitude is
+   meaningful.
 3. For aligned channels where their relationship is the anomaly, start with
    `temporal_envelope_multivariate`.
-4. Deprioritize offline models; retain them only for legacy use or when comparative validation
-   establishes a clear benefit.
+4. Do not introduce an offline model in the normal recommendation flow. Discuss one only when
+   reviewing a legacy configuration, when the user explicitly requests it, or when a controlled
+   comparison has already established a material benefit that an online model cannot provide.
 
 ### 6. Map domain knowledge to public controls
 

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
@@ -8,7 +8,7 @@ override static examples.
 - [Decision tree](#decision-tree)
 - [Temporal Envelope](#temporal-envelope)
 - [Simple online models](#simple-online-models)
-- [Offline and specialized alternatives](#offline-and-specialized-alternatives)
+- [Legacy offline models](#legacy-offline-models)
 - [Fit-window and cadence guidance](#fit-window-and-cadence-guidance)
 - [Autotune guidance](#autotune-guidance)
 
@@ -113,35 +113,29 @@ For stable MAD, Z-score, and online-quantile distributions, use `history_strengt
 This can reduce fit-time data, CPU, and RAM, but it does not replace coverage of every required
 seasonal phase and should not anchor a genuinely changing regime.
 
-## Offline and specialized alternatives
+## Legacy offline models
+
+Do not include offline models in the ordinary candidate set for new configurations or use one as
+a fallback when the profile is uncertain. Prefer the corresponding online model. Mention an
+offline model only when auditing an existing legacy configuration, when the user explicitly asks
+for it, or when a controlled comparison has already shown a material requirement the online model
+does not meet.
 
 ### `prophet`
 
-Deprioritize Prophet: vmanomaly cannot currently pass external regressors through its API, while
-Temporal Envelope covers the supported online trend/calendar/holiday use cases. Keep Prophet only
-for legacy or comparative configurations that demonstrably perform better. For `step < 1h`, use
-frozen compression such as:
-
-```yaml
-compression:
-  window: 1h
-  agg_method: mean
-  adjust_boundaries: true
-```
-
-Preserve the final inference step. Use a smaller compression window only when sub-hour patterns
-matter.
+Temporal Envelope covers the preferred online trend, calendar, holiday, shift, and forecast
+workflow. Keep Prophet only for an existing legacy configuration or when the user explicitly
+requests it and validation establishes a material benefit.
 
 ### `holtwinters`
 
-Deprioritize Holt-Winters in new configurations. Prefer an online model unless comparative
-validation establishes a clear benefit.
+Keep Holt-Winters only for an existing legacy configuration or an explicit, validated requirement.
 
 ### Isolation Forest
 
-Deprioritize Isolation Forest in new configurations. It does not extrapolate a temporal forecast
-and must be periodically refitted; retain it only when feature-space anomaly validation clearly
-outperforms the corresponding online model.
+Isolation Forest requires periodic refitting and does not extrapolate a temporal forecast. Keep it
+only for an existing legacy configuration or an explicit, validated feature-space requirement;
+use Temporal Envelope Multivariate for the normal cross-channel recommendation path.
 
 ## Fit-window and cadence guidance
 

--- a/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
@@ -178,9 +178,9 @@ Useful controls:
 - `frozen_params` for fixed domain/model choices such as direction, holidays, or multivariate
   `groupby`
 
-For sub-hour Prophet tuning, freeze compression when appropriate while preserving the final query
-step. For multivariate models, keep group structure fixed rather than treating it as an optimizer
-dimension.
+For multivariate models, keep group structure fixed rather than treating it as an optimizer
+dimension. Treat offline-model tuning as a legacy or explicitly requested workflow, not a default
+candidate path.
 
 Creation returns a task ID immediately. Poll `GET /api/v1/autotune/tasks/{id}` until `done`,
 `error`, or `canceled`.

--- a/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
@@ -132,12 +132,14 @@ population counts from them.
 
 Model-fit expectations:
 
-- complex trend/calendar/holiday/shift profile: `temporal_envelope` is the preferred first check;
-- simple non-seasonal heavy-tailed profile: `mad_online`;
-- stable/light-tailed simple profile: `zscore_online`;
-- dependency anomaly: `temporal_envelope_multivariate`, with Isolation Forest as an offline
-  feature-space alternative;
-- Prophet is a fallback for its specific regressors/decomposition or when validation favors it.
+- non-trivial trend/calendar/holiday/shift profile, or uncertainty about a simple stationary
+  baseline: `temporal_envelope` is the preferred first check;
+- confirmed simple, non-seasonal, heavy-tailed or outlier-contaminated profile: `mad_online`;
+- confirmed simple, stable/light-tailed profile: `zscore_online`;
+- dependency anomaly: `temporal_envelope_multivariate`.
+
+Do not recommend an offline model as a fallback. When reviewing one, treat it as a legacy or
+explicitly requested choice and compare it with the corresponding online model.
 
 ### 6. Reproduce with a bounded task
 

--- a/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
@@ -70,9 +70,11 @@ be stated. Completely empty fit history requires causal cold-start and delays tr
 | simple stable/light-tailed data | `zscore_online` |
 | trend, several calendar profiles, holidays, or persistent shifts | `temporal_envelope` |
 | normality is a changing relationship between aligned channels | `temporal_envelope_multivariate` |
-| custom regressors or Prophet decomposition required | `prophet` |
-| generic feature-space outlier across aligned series | `isolation_forest_multivariate` |
-| generic feature-space outlier within one series | `isolation_forest_univariate` |
+
+When the profile is not demonstrably simple and stationary, start the comparison with Temporal
+Envelope rather than treating an offline model as the fallback. Offline models are not first
+candidates for new configurations. Review them only as legacy or explicitly requested choices,
+and compare them with the corresponding online model.
 
 Temporal Envelope profile names are shape hypotheses, not knobs to enable indiscriminately:
 


### PR DESCRIPTION
### Intention

Make vmanomaly model selection consistently favor Temporal Envelope for non-trivial or uncertain profiles, reserving MAD/Z-score for simple stationary data.

Offline models are now treated as legacy or explicitly requested choices. This prevents unintended "default to Prophet" recommendations across configuration, review, and autotune workflows.