### PR TITLE
docs: align vmanomaly v1.30.3 guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "VictoriaMetrics"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "plugins": [
     {
       "name": "query",

--- a/plugins/vmanomaly/.claude-plugin/plugin.json
+++ b/plugins/vmanomaly/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vmanomaly",
   "description": "Configure, operate, and review VictoriaMetrics Anomaly Detection. Profile time series, select and tune models, validate configurations, run bounded detection tasks, and check persisted-state compatibility.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "VictoriaMetrics"
   },

--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -71,6 +71,8 @@ Treat the compatibility response as a preflight, not a cleanup action:
 - never delete state without explicit user approval;
 - use `?version_to=X.Y.Z` for a planned upgrade.
 
+Compatibility covers vmanomaly-managed state, supported readers, and built-in models, not custom model code, dependencies, or state; before upgrading to v1.30.3+, custom many-to-one models relying on `is_multivariate = True` must declare `topology = ModelTopology.MANY_TO_ONE`.
+
 Only the GET compatibility check exists in v1.30.
 
 ### 4. Profile real data
@@ -167,14 +169,16 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/config/validate" | jq .
 ```
 
-Then check capacity and run a bounded detection task using the validated model:
+Then check capacity and run a bounded detection task using the validated model. The v1.30.3 task contract requires an explicit `datasource_url`; reuse the configured datasource URL when appropriate:
 
 ```bash
 curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
 
-jq -n --arg query "$QUERY" --slurpfile model model.json '{
+DATASOURCE_URL='<configured-or-explicit-datasource-url>'
+jq -n --arg query "$QUERY" --arg datasource_url "$DATASOURCE_URL" --slurpfile model model.json '{
     query:$query,
+    datasource_url:$datasource_url,
     step:"5m",
     fit_window:"30d",
     fit_every:"1000w",

--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -1,23 +1,15 @@
 ---
 name: vmanomaly-config
 description: >
-  Design, tune, validate, and test VictoriaMetrics vmanomaly configurations for known metrics
-  or LogsQL queries. Use when choosing static alerting versus ML, selecting a vmanomaly model,
-  configuring Temporal Envelope, building deployment YAML, tuning anomaly sensitivity, or
-  creating VMAlert rules. Trigger on anomaly configuration, model selection, shared autotune,
-  seasonal anomaly detection, forecasting, or "how should I monitor this metric?" Do not use
-  for open-ended discovery across unknown signals.
+  Design, tune, validate, and test VictoriaMetrics vmanomaly configurations for known metrics or LogsQL queries. Use when choosing static alerting versus ML, selecting a vmanomaly model, configuring Temporal Envelope, building deployment YAML, tuning anomaly sensitivity, or creating VMAlert rules. Trigger on anomaly configuration, model selection, shared autotune, seasonal anomaly detection, forecasting, or "how should I monitor this metric?" Do not use for open-ended discovery across unknown signals.
 allowed-tools: Bash(curl:*), Bash(jq:*), Read
 ---
 
 # vmanomaly configuration builder
 
-Turn a known monitoring intent into a validated vmanomaly v1.30+ configuration. ML must earn its
-operational cost: first decide whether a static rule expresses the failure condition more clearly.
+Turn a known monitoring intent into a validated vmanomaly v1.30+ configuration. ML must earn its operational cost: first decide whether a static rule expresses the failure condition more clearly.
 
-Read `references/model-selection.md` before selecting a model or its parameters.
-When producing a continuously running deployment, also read
-`references/deployment-readiness.md` and apply only the controls whose conditions match.
+Read `references/model-selection.md` before selecting a model or its parameters. When producing a continuously running deployment, also read `references/deployment-readiness.md` and apply only the controls whose conditions match.
 
 ## Environment
 
@@ -28,8 +20,7 @@ export VM_ANOMALY_URL="https://vmanomaly.example.com"
 export VM_CURL_CONFIG="${VM_CURL_CONFIG:-/dev/null}"
 ```
 
-Include any configured path prefix in `VM_ANOMALY_URL`. Never print or create the credential file.
-Ask for the URL when it is unavailable.
+Include any configured path prefix in `VM_ANOMALY_URL`. Never print or create the credential file. Ask for the URL when it is unavailable.
 
 ## Workflow
 
@@ -45,12 +36,9 @@ Collect or infer:
 - known physical bounds and insignificant absolute/relative deviations;
 - sensitivity preference and acceptable upper detection rate.
 
-If the model-query field is empty but the user already supplied a query, use it for profiling and
-recommend placing it in the UI query input. If no query exists, ask for one. Do not invent a
-production query from a metric description.
+If the model-query field is empty but the user already supplied a query, use it for profiling and recommend placing it in the UI query input. If no query exists, ask for one. Do not invent a production query from a metric description.
 
-When installed, `victoriametrics-query` or `victorialogs-query` may help discover names, labels,
-and valid expressions. Their absence must not block this skill.
+When installed, `victoriametrics-query` or `victorialogs-query` may help discover names, labels, and valid expressions. Their absence must not block this skill.
 
 ### 2. Triage static alerting versus ML
 
@@ -63,9 +51,7 @@ Prefer a static VMAlert rule when a clear bad value exists:
 | binary/up-down state | direct threshold, `absent()`, or `changes()` |
 | expiry or hard safety limit | direct threshold |
 
-Use vmanomaly when normal varies by time, instance, workload, or a drifting baseline; when daily,
-weekly, monthly, or holiday structure matters; or when a cross-series relationship is the signal.
-Present this decision before spending an autotune budget.
+Use vmanomaly when normal varies by time, instance, workload, or a drifting baseline; when daily, weekly, monthly, or holiday structure matters; or when a cross-series relationship is the signal. Present this decision before spending an autotune budget.
 
 ### 3. Run the runtime preflight
 
@@ -104,9 +90,7 @@ curl -q --config "$VM_CURL_CONFIG" -sG \
   "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
 ```
 
-Use measured trend, daily/weekly/monthly profiles, shape, eligibility, and coverage rather than
-guessing from the metric name. A limited result is a sample. If a limited read returns a split-
-chunk 422, shorten the interval or use a coarser step.
+Use measured trend, daily/weekly/monthly profiles, shape, eligibility, and coverage rather than guessing from the metric name. A limited result is a sample. If a limited read returns a split-chunk 422, shorten the interval or use a coarser step.
 
 ### 5. Discover and select a supported model
 
@@ -118,44 +102,24 @@ curl -q --config "$VM_CURL_CONFIG" -sG \
   "$VM_ANOMALY_URL/api/v1/model/schema" | jq .
 ```
 
-Use the live alias list and schema as authoritative. Rebuild the model spec when changing class;
-never carry stale parameters across classes.
+Use the live alias list and schema as authoritative. Rebuild the model spec when changing class; never carry stale parameters across classes.
 
 Default hierarchy:
 
-1. Start with `temporal_envelope` for any non-trivial temporal profile: trend, calendar patterns,
-   holidays, persistent shifts, forecasts, or uncertainty about whether a simple stationary
-   baseline is sufficient.
-2. Use `mad_online` or `zscore_online` only when profiling confirms simple, non-seasonal,
-   relatively stable data. Prefer MAD for skewed, heavy-tailed, or outlier-contaminated data; use
-   Z-score only when the distribution is stable/light-tailed and standard-deviation magnitude is
-   meaningful.
-3. For aligned channels where their relationship is the anomaly, start with
-   `temporal_envelope_multivariate`.
-4. Do not introduce an offline model in the normal recommendation flow. Discuss one only when
-   reviewing a legacy configuration, when the user explicitly requests it, or when a controlled
-   comparison has already established a material benefit that an online model cannot provide.
+1. Start with `temporal_envelope` for any non-trivial temporal profile: trend, calendar patterns, holidays, persistent shifts, forecasts, or uncertainty about whether a simple stationary baseline is sufficient.
+2. Use `mad_online` or `zscore_online` only when profiling confirms simple, non-seasonal, relatively stable data. Prefer MAD for skewed, heavy-tailed, or outlier-contaminated data; use Z-score only when the distribution is stable/light-tailed and standard-deviation magnitude is meaningful.
+3. For aligned channels where their relationship is the anomaly, start with `temporal_envelope_multivariate`.
+4. Do not introduce an offline model in the normal recommendation flow. Discuss one only when reviewing a legacy configuration, when the user explicitly requests it, or when a controlled comparison has already established a material benefit that an online model cannot provide.
 
 ### 6. Map domain knowledge to public controls
 
-- Fix `detection_direction` when business intent is known, and map insignificant absolute/relative
-  deviations to `min_dev_from_expected` and `min_rel_dev_from_expected`.
-- In v1.30.2+ deployable YAML, place `data_range`, `detection_direction`,
-  `min_dev_from_expected`, and `min_rel_dev_from_expected` under
-  `reader.queries.<alias>`. Query values are authoritative across attached models; model-level
-  values remain compatible local fallbacks but are deprecated.
-- For VMUI or an ad-hoc detection task, keep these fields in `model_spec`: the UI suggestion/query
-  contract does not expose per-query business-policy fields. The backend maps `data_range` to the
-  temporary query and resolves the other fields as model-local compatibility values.
-- Set model-level `clip_predictions` only when forecast and interval outputs should be clipped to
-  that domain.
-- Use `min_n_samples_seen` to suppress scores during cold-start; express its duration as samples
-  multiplied by query step.
-- For stable MAD, Z-score, or online-quantile data, consider `history_strength > 1` instead of many
-  extra fit cycles; keep enough history to cover every required seasonal phase.
-- Select only calendar presets supported by the profile. Temporal Envelope profiles are timezone-
-  and DST-aware; set `reader.queries.<alias>.tz` (or the reader-level `tz`) to the same IANA
-  timezone used during profiling.
+- Fix `detection_direction` when business intent is known, and map insignificant absolute/relative deviations to `min_dev_from_expected` and `min_rel_dev_from_expected`.
+- In v1.30.2+ deployable YAML, place `data_range`, `detection_direction`, `min_dev_from_expected`, and `min_rel_dev_from_expected` under `reader.queries.<alias>`. Query values are authoritative across attached models; model-level values remain compatible local fallbacks but are deprecated.
+- For VMUI or an ad-hoc detection task, keep these fields in `model_spec`: the UI suggestion/query contract does not expose per-query business-policy fields. The backend maps `data_range` to the temporary query and resolves the other fields as model-local compatibility values.
+- Set model-level `clip_predictions` only when forecast and interval outputs should be clipped to that domain.
+- Use `min_n_samples_seen` to suppress scores during cold-start; express its duration as samples multiplied by query step.
+- For stable MAD, Z-score, or online-quantile data, consider `history_strength > 1` instead of many extra fit cycles; keep enough history to cover every required seasonal phase.
+- Select only calendar presets supported by the profile. Temporal Envelope profiles are timezone- and DST-aware; set `reader.queries.<alias>.tz` (or the reader-level `tz`) to the same IANA timezone used during profiling.
 - Keep `forecast_at` empty unless the user needs future-state forecasting or capacity planning.
 - Keep multivariate `groupby`, holidays, and other domain structure fixed during autotune.
 
@@ -163,8 +127,7 @@ Default hierarchy:
 
 For a direct configuration, begin with schema defaults and change only justified controls.
 
-For shared autotune, first select the model class. State the trial/time budget, then create one
-bounded task. Use causal exact validation for online models:
+For shared autotune, first select the model class. State the trial/time budget, then create one bounded task. Use causal exact validation for online models:
 
 ```bash
 jq -n --arg query "$QUERY" --arg timezone "$TIMEZONE" '{
@@ -184,11 +147,7 @@ jq -n --arg query "$QUERY" --arg timezone "$TIMEZONE" '{
   "$VM_ANOMALY_URL/api/v1/autotune/tasks" | jq .
 ```
 
-Poll `GET /api/v1/autotune/tasks/{task_id}` sequentially. On success, use the concrete
-`result_data.data.modelConfig`, validate it, and test it. Do not substitute `class: auto`; that
-wrapper retunes during each fit and is a separate, explicitly chosen lifecycle. Autotune still
-returns a model spec: keep frozen business fields there for VMUI/ad-hoc testing, but move them to
-the corresponding query when assembling v1.30.2+ deployment YAML.
+Poll `GET /api/v1/autotune/tasks/{task_id}` sequentially. On success, use the concrete `result_data.data.modelConfig`, validate it, and test it. Do not substitute `class: auto`; that wrapper retunes during each fit and is a separate, explicitly chosen lifecycle. Autotune still returns a model spec: keep frozen business fields there for VMUI/ad-hoc testing, but move them to the corresponding query when assembling v1.30.2+ deployment YAML.
 
 ### 8. Validate and test
 
@@ -231,14 +190,9 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks/<task_id>" | jq .
 ```
 
-Poll the returned task ID sequentially until `done`, `error`, or `canceled`. For online models use
-`exact:true` and default to an effectively disabled refit cadence such as `fit_every: 1000w`, so
-the initial fit evolves causally during inference. Configure periodic refits only when explicitly
-needed.
+Poll the returned task ID sequentially until `done`, `error`, or `canceled`. For online models use `exact:true` and default to an effectively disabled refit cadence such as `fit_every: 1000w`, so the initial fit evolves causally during inference. Configure periodic refits only when explicitly needed.
 
-Evaluate detections visually and against known events. Without ground-truth labels, call the
-observed fraction a **detection rate**, not a false-positive rate. Ask the user which detections
-were useful before tightening the model.
+Evaluate detections visually and against known events. Without ground-truth labels, call the observed fraction a **detection rate**, not a false-positive rate. Ask the user which detections were useful before tightening the model.
 
 ### 9. Deliver deployable artifacts
 
@@ -249,16 +203,10 @@ Provide:
 - rationale tied to profile evidence and business intent;
 - query step, fit window/cadence, warmup, expected reaction time, and resource caveats;
 - validation/test results and assumptions requiring production verification.
-- self-monitoring integration, with the official dashboard and alert rules recommended for
-  production rather than relying on point-in-time health checks.
-- justified state restoration, retention, hot-reload, persistence, and workload-distribution
-  choices from `references/deployment-readiness.md`.
+- self-monitoring integration, with the official dashboard and alert rules recommended for production rather than relying on point-in-time health checks.
+- justified state restoration, retention, hot-reload, persistence, and workload-distribution choices from `references/deployment-readiness.md`.
 
-Generated `/api/vmanomaly/config.yaml` and `/api/vmanomaly/example-alert-rule.yaml` output is a
-starting point, not proof of correctness. The config endpoint preserves the VMUI/model-spec
-compatibility shape; before presenting v1.30.2+ deployment YAML, move the four stable business
-policies to `reader.queries.<alias>`, add `reader.workers` when appropriate, and validate the final
-configuration.
+Generated `/api/vmanomaly/config.yaml` and `/api/vmanomaly/example-alert-rule.yaml` output is a starting point, not proof of correctness. The config endpoint preserves the VMUI/model-spec compatibility shape; before presenting v1.30.2+ deployment YAML, move the four stable business policies to `reader.queries.<alias>`, add `reader.workers` when appropriate, and validate the final configuration.
 
 ## Safety
 

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
@@ -1,27 +1,21 @@
 # vmanomaly deployment-readiness reference
 
-Use this when a validated configuration will run continuously. Keep small deployments simple and
-add operational controls only when their conditions apply. The official
-[installation guide](https://docs.victoriametrics.com/anomaly-detection/quickstart/#how-to-install-and-run-vmanomaly)
-links Docker, Docker Compose, Helm, and Operator deployment paths.
+Use this when a validated configuration will run continuously. Keep small deployments simple and add operational controls only when their conditions apply. The official [installation guide](https://docs.victoriametrics.com/anomaly-detection/quickstart/#how-to-install-and-run-vmanomaly) links Docker, Docker Compose, Helm, and Operator deployment paths.
 
 ## Stateful online operation
 
-For periodic online models, prefer one initial fit followed by causal inference updates. Protect
-that accumulated state across restarts:
+For periodic online models, prefer one initial fit followed by causal inference updates. Protect that accumulated state across restarts:
 
 - set `settings.restore_state: true`;
 - enable on-disk model and reader-data storage, which state restoration requires;
 - mount the dump directories on durable storage rather than an ephemeral container filesystem;
 - run the compatibility preflight before upgrades or changing persisted-state layout.
 
-State reuse is exact only while model, query, and scheduler identity remains compatible. Parameter,
-query, or sharding changes may invalidate or relocate some state and trigger a fresh fit.
+State reuse is exact only while model, query, and scheduler identity remains compatible. Parameter, query, or sharding changes may invalidate or relocate some state and trigger a fresh fit.
 
 ## Retention and high churn
 
-Configure [`settings.retention`](https://docs.victoriametrics.com/anomaly-detection/components/settings/#retention)
-when labelsets appear and disappear, especially with online models or state restoration:
+Configure [`settings.retention`](https://docs.victoriametrics.com/anomaly-detection/components/settings/#retention) when labelsets appear and disappear, especially with online models or state restoration:
 
 ```yaml
 settings:
@@ -33,30 +27,23 @@ settings:
 
 Treat these values as an example, not a default:
 
-- choose `ttl` longer than the longest legitimate absence of an active series; otherwise an
-  intermittent but valid model may cold-start when it returns;
-- use a shorter TTL for high-churn ephemeral labelsets and a longer one for intermittent business
-  series;
+- choose `ttl` longer than the longest legitimate absence of an active series; otherwise an intermittent but valid model may cold-start when it returns;
+- use a shorter TTL for high-churn ephemeral labelsets and a longer one for intermittent business series;
 - keep `check_interval < ttl` and below the smallest configured `fit_every`;
-- if `ttl` exceeds an offline model's `fit_every`, refitting normally replaces its state before
-  retention can clean it.
+- if `ttl` exceeds an offline model's `fit_every`, refitting normally replaces its state before retention can clean it.
 
-Retention removes stale model/training artifacts; it does not replace source-side metric retention
-or output-series lifecycle policies.
+Retention removes stale model/training artifacts; it does not replace source-side metric retention or output-series lifecycle policies.
 
 ## Configuration lifecycle
 
-Use content-polled hot reload when configuration files or Kubernetes ConfigMaps are managed
-externally:
+Use content-polled hot reload when configuration files or Kubernetes ConfigMaps are managed externally:
 
-- start with `--watch` and set `-configCheckInterval` only when the default check cadence is
-  unsuitable;
+- start with `--watch` and set `-configCheckInterval` only when the default check cadence is unsuitable;
 - validate the full YAML before rollout;
 - monitor `vmanomaly_config_last_reload_successful` and reload counters;
 - combine hot reload with state restoration to reuse compatible state.
 
-Do not promise zero model reinitialization: changing model parameters, queries, schedulers, or shard
-assignment may require new state.
+Do not promise zero model reinitialization: changing model parameters, queries, schedulers, or shard assignment may require new state.
 
 ## Workload and resource controls
 
@@ -72,23 +59,13 @@ assignment may require new state.
 | `writer.batch_max_series` / `writer.batch_max_bytes` | high-cardinality outputs or measured remote-write request limits | reducing batches without throughput, memory, or receiver evidence |
 | `writer.metric_prefix_cache_max_entries` | prefixing many dynamic metric names needs a bounded cache | changing the default without measured cache pressure |
 
-Keep `infer_every` aligned with the required alert reaction time. Scattering smooths work within
-that interval; it does not increase total capacity by itself. `reader.workers` bounds datasource
-work, `settings.n_workers` controls model processes, and `native_threads_per_worker` bounds native
-threads inside each process.
+Keep `infer_every` aligned with the required alert reaction time. Scattering smooths work within that interval; it does not increase total capacity by itself. `reader.workers` bounds datasource work, `settings.n_workers` controls model processes, and `native_threads_per_worker` bounds native threads inside each process.
 
 ## Scale-out and high availability
 
-Introduce sharding only after one instance is resource-bound or when isolation is operationally
-required. Add replication only for an explicit availability objective. Replicated writers require
-VictoriaMetrics-side deduplication to avoid duplicate output samples. Hot reload can redistribute
-sub-configurations between shards, reducing state-restoration reuse.
+Introduce sharding only after one instance is resource-bound or when isolation is operationally required. Add replication only for an explicit availability objective. Replicated writers require VictoriaMetrics-side deduplication to avoid duplicate output samples. Hot reload can redistribute sub-configurations between shards, reducing state-restoration reuse.
 
-Round-robin remains the ordinary sharding strategy. Use rendezvous sharding only when stable
-assignment during configuration changes materially improves state reuse; set
-`VMANOMALY_SHARDING_STRATEGY=RENDEZVOUS` on every shard and remember that changing the shard count
-can still move assignments. In Operator deployments, pass this setting through `extraEnvs` rather
-than treating it as a writer option.
+Round-robin remains the ordinary sharding strategy. Use rendezvous sharding only when stable assignment during configuration changes materially improves state reuse; set `VMANOMALY_SHARDING_STRATEGY=RENDEZVOUS` on every shard and remember that changing the shard count can still move assignments. In Operator deployments, pass this setting through `extraEnvs` rather than treating it as a writer option.
 
 ## Production handoff
 

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/deployment-readiness.md
@@ -69,6 +69,8 @@ assignment may require new state.
 | on-disk mode | model/data cardinality causes RAM pressure or state restoration is enabled | latency-sensitive small in-memory workloads, unless needed for restoration |
 | query-range splitting | long fit reads hit memory, timeout, or datasource limits | bounded reads already complete reliably |
 | `reader.series_processing_batch_size` tuning | measured processing memory/throughput bottleneck | changing the default without evidence |
+| `writer.batch_max_series` / `writer.batch_max_bytes` | high-cardinality outputs or measured remote-write request limits | reducing batches without throughput, memory, or receiver evidence |
+| `writer.metric_prefix_cache_max_entries` | prefixing many dynamic metric names needs a bounded cache | changing the default without measured cache pressure |
 
 Keep `infer_every` aligned with the required alert reaction time. Scattering smooths work within
 that interval; it does not increase total capacity by itself. `reader.workers` bounds datasource
@@ -81,6 +83,12 @@ Introduce sharding only after one instance is resource-bound or when isolation i
 required. Add replication only for an explicit availability objective. Replicated writers require
 VictoriaMetrics-side deduplication to avoid duplicate output samples. Hot reload can redistribute
 sub-configurations between shards, reducing state-restoration reuse.
+
+Round-robin remains the ordinary sharding strategy. Use rendezvous sharding only when stable
+assignment during configuration changes materially improves state reuse; set
+`VMANOMALY_SHARDING_STRATEGY=RENDEZVOUS` on every shard and remember that changing the shard count
+can still move assignments. In Operator deployments, pass this setting through `extraEnvs` rather
+than treating it as a writer option.
 
 ## Production handoff
 

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
@@ -1,7 +1,6 @@
 # vmanomaly v1.30 model-selection reference
 
-Use this after profiling real data. Runtime `/api/v1/models` and `/api/v1/model/schema` results
-override static examples.
+Use this after profiling real data. Runtime `/api/v1/models` and `/api/v1/model/schema` results override static examples.
 
 ## Contents
 
@@ -27,18 +26,13 @@ Can a static rule clearly express failure?
       └─ temporal_envelope_multivariate
 ```
 
-For deterministic failures, consult
-[Awesome Prometheus Alerts](https://samber.github.io/awesome-prometheus-alerts/) for reusable static
-rules before creating an ML detector. Adapt rules to the actual metric semantics and validate them;
-do not apply presets blindly.
+For deterministic failures, consult [Awesome Prometheus Alerts](https://samber.github.io/awesome-prometheus-alerts/) for reusable static rules before creating an ML detector. Adapt rules to the actual metric semantics and validate them; do not apply presets blindly.
 
 Do not call hour-of-day seasonality “weekly.” HOD is a daily local-hour pattern; DOW is weekly.
 
 ## Temporal Envelope
 
-Temporal Envelope is the preferred online tradeoff for complex operational and business data. It
-models evolving trend, robust residual bounds, calendar and holiday behavior, persistent shifts,
-and optional forecasts with bounded online state.
+Temporal Envelope is the preferred online tradeoff for complex operational and business data. It models evolving trend, robust residual bounds, calendar and holiday behavior, persistent shifts, and optional forecasts with bounded online state.
 
 Starting public controls:
 
@@ -61,9 +55,7 @@ Calendar presets:
 - `weekpart_plateau`
 - `month_smooth`, `month_plateau`
 
-`smooth` means a gradual curve, `spiky` a narrow recurring peak, and `plateau` a sustained phase.
-Choose only evidence-backed profiles. They use the configured civil timezone and remain aligned
-across DST transitions.
+`smooth` means a gradual curve, `spiky` a narrow recurring peak, and `plateau` a sustained phase. Choose only evidence-backed profiles. They use the configured civil timezone and remain aligned across DST transitions.
 
 Example:
 
@@ -80,54 +72,39 @@ models:
 
 ### Multivariate form
 
-Use `temporal_envelope_multivariate` only when aligned channel relationships are meaningful. Each
-channel retains its own trend/calendar profile, while dependencies contribute to one joint score.
+Use `temporal_envelope_multivariate` only when aligned channel relationships are meaningful. Each channel retains its own trend/calendar profile, while dependencies contribute to one joint score.
 
 - default output is the one joint `anomaly_score` to limit cardinality;
 - `dependency_rank` defaults to `8`; `0` disables dependency features;
 - `score_aggregation` defaults to `l2`; autotune can compare `max`, `mean`, and `l2`;
-- `groupby` creates a separate multivariate model per label combination and must be frozen/domain-
-  selected rather than optimized;
+- `groupby` creates a separate multivariate model per label combination and must be frozen/domain-selected rather than optimized;
 - `recommended_max_channels=100` is advisory; `max_channels=1000` is a hard safety limit;
 - explicitly requesting channel-level `y`/forecasts/bounds increases output cardinality;
-- per-channel diagnostics do not change the many-to-one model topology: topology describes the
-  joint scoring/routing contract, not the number of auxiliary output series.
+- per-channel diagnostics do not change the many-to-one model topology: topology describes the joint scoring/routing contract, not the number of auxiliary output series.
 
 ## Simple online models
 
 ### `mad_online`
 
-Use for robust point anomalies on simple, non-seasonal, relatively stable metrics. It tolerates
-outliers and has very low operational cost, but does not explicitly model trend/calendar patterns.
+Use for robust point anomalies on simple, non-seasonal, relatively stable metrics. It tolerates outliers and has very low operational cost, but does not explicitly model trend/calendar patterns.
 
 ### `zscore_online`
 
-Use when the profile is stable/light-tailed and standard-deviation magnitude is meaningful. It is
-simple and explainable but more outlier-sensitive than MAD.
+Use when the profile is stable/light-tailed and standard-deviation magnitude is meaningful. It is simple and explainable but more outlier-sensitive than MAD.
 
 ### `quantile_online`
 
-Use for seasonal quantile behavior with absent or slow trend. It requires enough observations in
-each seasonal bucket and is not a general trend model.
+Use for seasonal quantile behavior with absent or slow trend. It requires enough observations in each seasonal bucket and is not a general trend model.
 
-For stable MAD, Z-score, and online-quantile distributions, use `history_strength > 1` (typically
-`2`–`3`) to reduce the leverage of new observations without fitting many extra historical cycles.
-This can reduce fit-time data, CPU, and RAM, but it does not replace coverage of every required
-seasonal phase and should not anchor a genuinely changing regime.
+For stable MAD, Z-score, and online-quantile distributions, use `history_strength > 1` (typically `2`–`3`) to reduce the leverage of new observations without fitting many extra historical cycles. This can reduce fit-time data, CPU, and RAM, but it does not replace coverage of every required seasonal phase and should not anchor a genuinely changing regime.
 
 ## Legacy offline models
 
-Do not include offline models in the ordinary candidate set for new configurations or use one as
-a fallback when the profile is uncertain. Prefer the corresponding online model. Mention an
-offline model only when auditing an existing legacy configuration, when the user explicitly asks
-for it, or when a controlled comparison has already shown a material requirement the online model
-does not meet.
+Do not include offline models in the ordinary candidate set for new configurations or use one as a fallback when the profile is uncertain. Prefer the corresponding online model. Mention an offline model only when auditing an existing legacy configuration, when the user explicitly asks for it, or when a controlled comparison has already shown a material requirement the online model does not meet.
 
 ### `prophet`
 
-Temporal Envelope covers the preferred online trend, calendar, holiday, shift, and forecast
-workflow. Keep Prophet only for an existing legacy configuration or when the user explicitly
-requests it and validation establishes a material benefit.
+Temporal Envelope covers the preferred online trend, calendar, holiday, shift, and forecast workflow. Keep Prophet only for an existing legacy configuration or when the user explicitly requests it and validation establishes a material benefit.
 
 ### `holtwinters`
 
@@ -135,9 +112,7 @@ Keep Holt-Winters only for an existing legacy configuration or an explicit, vali
 
 ### Isolation Forest
 
-Isolation Forest requires periodic refitting and does not extrapolate a temporal forecast. Keep it
-only for an existing legacy configuration or an explicit, validated feature-space requirement;
-use Temporal Envelope Multivariate for the normal cross-channel recommendation path.
+Isolation Forest requires periodic refitting and does not extrapolate a temporal forecast. Keep it only for an existing legacy configuration or an explicit, validated feature-space requirement; use Temporal Envelope Multivariate for the normal cross-channel recommendation path.
 
 ## Fit-window and cadence guidance
 
@@ -147,21 +122,16 @@ use Temporal Envelope Multivariate for the normal cross-channel recommendation p
 | DOW/weekly | `2w` | `30d` |
 | month-of-year | `24mo` when feasible | `24mo+` |
 
-Use the longest required history for multiple profiles. Explain when available history is shorter.
-Partial fit history can still be useful for online models, but cold-start/warmup remains visible.
+Use the longest required history for multiple profiles. Explain when available history is shorter. Partial fit history can still be useful for online models, but cold-start/warmup remains visible.
 
-For online models, default `fit_every` to an effectively disabled cadence such as `1000w`: perform
-one initial fit, then improve state causally during inference. Configure periodic refits only when
-the user explicitly needs resets or relearning. Offline models require periodic refits, which is
-another reason to deprioritize them.
+For online models, default `fit_every` to an effectively disabled cadence such as `1000w`: perform one initial fit, then improve state causally during inference. Configure periodic refits only when the user explicitly needs resets or relearning. Offline models require periodic refits, which is another reason to deprioritize them.
 
 ## Autotune guidance
 
 - Autotune a selected model; v1.30 shared autotune does not choose a class.
 - `anomaly_percentage` is an upper detection-volume constraint, not a target count.
 - Use `exact:true` for online validation to match causal production inference.
-- Keep business facts frozen: known direction, data bounds, holidays, `groupby`, and mandatory
-  thresholds.
+- Keep business facts frozen: known direction, data bounds, holidays, `groupby`, and mandatory thresholds.
 - Optimize complexity when comparable candidates exist so simpler fitted state wins ties.
 - Apply and validate returned `result_data.data.modelConfig`.
 - Deploy `class: auto` only when refit-time retuning is explicitly desired.

--- a/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/references/model-selection.md
@@ -89,7 +89,9 @@ channel retains its own trend/calendar profile, while dependencies contribute to
 - `groupby` creates a separate multivariate model per label combination and must be frozen/domain-
   selected rather than optimized;
 - `recommended_max_channels=100` is advisory; `max_channels=1000` is a hard safety limit;
-- explicitly requesting channel-level `y`/forecasts/bounds increases output cardinality.
+- explicitly requesting channel-level `y`/forecasts/bounds increases output cardinality;
+- per-channel diagnostics do not change the many-to-one model topology: topology describes the
+  joint scoring/routing contract, not the number of auxiliary output series.
 
 ## Simple online models
 

--- a/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
@@ -1,19 +1,13 @@
 ---
 name: vmanomaly-query
 description: >
-  Operate VictoriaMetrics Anomaly Detection (vmanomaly) through its HTTP API. Use when checking
-  health, versions, persisted-state compatibility, self-monitoring metrics, available models,
-  model schemas, server queries, time-series characteristics, shared autotune, or asynchronous
-  detection tasks. Also use for generating and validating vmanomaly configuration or alert-rule
-  YAML. Triggers on vmanomaly API, anomaly tasks, model validation, model schema, compatibility,
-  Temporal Envelope, time-series profiling, and vmanomaly autotune.
+  Operate VictoriaMetrics Anomaly Detection (vmanomaly) through its HTTP API. Use when checking health, versions, persisted-state compatibility, self-monitoring metrics, available models, model schemas, server queries, time-series characteristics, shared autotune, or asynchronous detection tasks. Also use for generating and validating vmanomaly configuration or alert-rule YAML. Triggers on vmanomaly API, anomaly tasks, model validation, model schema, compatibility, Temporal Envelope, time-series profiling, and vmanomaly autotune.
 allowed-tools: Bash(curl:*), Bash(jq:*)
 ---
 
 # vmanomaly API
 
-Operate a running vmanomaly v1.30+ instance through bounded, explicit API calls. Prefer live
-schemas and server responses over static assumptions.
+Operate a running vmanomaly v1.30+ instance through bounded, explicit API calls. Prefer live schemas and server responses over static assumptions.
 
 ## Environment and authentication
 
@@ -53,13 +47,11 @@ Interpret compatibility conservatively:
 
 - `global_check.has_state=false`: no persisted state needs migration.
 - `global_check.is_compatible=true`: the checked state can be reused.
-- `global_check.drop_everything=true`: report that all persisted state must be dropped; do not
-  perform the drop automatically.
+- `global_check.drop_everything=true`: report that all persisted state must be dropped; do not perform the drop automatically.
 - `component_assessment.models_to_purge` or `should_purge_reader_data`: report the scoped cleanup.
 - Use `?version_to=X.Y.Z` to assess the stored state against a planned target release.
 
-Only GET compatibility is implemented. Do not invent a POST endpoint for arbitrary provided
-configs. For configuration syntax, use `/api/v1/config/validate` instead.
+Only GET compatibility is implemented. Do not invent a POST endpoint for arbitrary provided configs. For configuration syntax, use `/api/v1/config/validate` instead.
 
 ## Discover capabilities before using them
 
@@ -72,8 +64,7 @@ curl -q --config "$VM_CURL_CONFIG" -sG \
   "$VM_ANOMALY_URL/api/v1/model/schema" | jq .
 ```
 
-Treat `/api/v1/models` and `/api/v1/model/schema` as authoritative. Do not carry parameters
-between model classes unless the target schema exposes them.
+Treat `/api/v1/models` and `/api/v1/model/schema` as authoritative. Do not carry parameters between model classes unless the target schema exposes them.
 
 ## Validate before running
 
@@ -120,22 +111,13 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/metrics?name[]=vmanomaly_scheduler_alive&name[]=vmanomaly_scheduler_restarts_total&name[]=vmanomaly_model_run_errors&name[]=vmanomaly_model_runs_skipped"
 ```
 
-Treat `/health` as a point-in-time preflight, not production monitoring. For a running deployment,
-recommend scraping or pushing the documented
-[self-monitoring metrics](https://docs.victoriametrics.com/anomaly-detection/components/monitoring/#metrics-generated-by-vmanomaly),
-installing the [Grafana dashboard](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#grafana-dashboard),
-and reviewing the supplied [alerting rules](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#alerting-rules).
-Prioritize service availability, scheduler liveness/restarts, reload failures, model errors/skips,
-I/O error rates, and resource pressure. Do not deploy rules or dashboards without user approval.
+Treat `/health` as a point-in-time preflight, not production monitoring. For a running deployment, recommend scraping or pushing the documented [self-monitoring metrics](https://docs.victoriametrics.com/anomaly-detection/components/monitoring/#metrics-generated-by-vmanomaly), installing the [Grafana dashboard](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#grafana-dashboard), and reviewing the supplied [alerting rules](https://docs.victoriametrics.com/anomaly-detection/self-monitoring/#alerting-rules). Prioritize service availability, scheduler liveness/restarts, reload failures, model errors/skips, I/O error rates, and resource pressure. Do not deploy rules or dashboards without user approval.
 
-When installed, use `victoriametrics-query` to verify that self-monitoring series are ingested and
-the expected rules are loaded; use `alertmanager-query` to inspect active, silenced, or inhibited
-vmanomaly alerts.
+When installed, use `victoriametrics-query` to verify that self-monitoring series are ingested and the expected rules are loaded; use `alertmanager-query` to inspect active, silenced, or inhibited vmanomaly alerts.
 
 ## Profile a query before choosing a model
 
-An exact non-empty query is required. If the user supplied one, reuse it. Otherwise resolve a
-configured query alias or ask the user; never invent a production query from a metric description.
+An exact non-empty query is required. If the user supplied one, reuse it. Otherwise resolve a configured query alias or ask the user; never invent a production query from a metric description.
 
 ```bash
 QUERY='sum(rate(http_requests_total{job="api"}[5m])) by (service)'
@@ -150,14 +132,11 @@ curl -q --config "$VM_CURL_CONFIG" -sG \
   "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
 ```
 
-Use the same `step` for profiling, autotune, and the final task/config. Treat a limited response
-as a sample, not an exact population summary. If a limited read returns a split-chunk `422`, use
-a shorter interval or coarser step.
+Use the same `step` for profiling, autotune, and the final task/config. Treat a limited response as a sample, not an exact population summary. If a limited read returns a split-chunk `422`, use a shorter interval or coarser step.
 
 ## Run shared autotune
 
-Choose `tuned_class_name` first from the profile, business intent, `/api/v1/models`, and schema.
-Shared v1.30 autotune does not choose the model class.
+Choose `tuned_class_name` first from the profile, business intent, `/api/v1/models`, and schema. Shared v1.30 autotune does not choose the model class.
 
 ```bash
 jq -n --arg query "$QUERY" --arg timezone "$TIMEZONE" '{
@@ -184,12 +163,7 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/autotune/tasks/<task_id>" | jq .
 ```
 
-Treat `done`, `error`, and `canceled` as terminal. On `done`, apply
-`result_data.data.modelConfig` directly, validate it, and test it. Do not replace this concrete
-one-time recommendation with `class: auto`; the deployable auto wrapper has a different lifecycle.
-Business policies in this result remain model-spec fields for task/UI compatibility; move them to
-the attached query only when constructing a v1.30.2+ deployment configuration.
-Use DELETE only when the user asks to cancel:
+Treat `done`, `error`, and `canceled` as terminal. On `done`, apply `result_data.data.modelConfig` directly, validate it, and test it. Do not replace this concrete one-time recommendation with `class: auto`; the deployable auto wrapper has a different lifecycle. Business policies in this result remain model-spec fields for task/UI compatibility; move them to the attached query only when constructing a v1.30.2+ deployment configuration. Use DELETE only when the user asks to cancel:
 
 ```bash
 curl -q --config "$VM_CURL_CONFIG" -s \
@@ -222,29 +196,20 @@ jq -n --arg query "$QUERY" '{
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks" | jq .
 ```
 
-Use `exact:true` for causal online-model evaluation. Poll sequentially and never create duplicate
-tasks merely because a task is still running.
+Use `exact:true` for causal online-model evaluation. Poll sequentially and never create duplicate tasks merely because a task is still running.
 
 ## Generate deployment artifacts
 
-Use `/api/vmanomaly/config.yaml` for an example configuration and
-`/api/vmanomaly/example-alert-rule.yaml` for a VMAlert rule. Pass values with `--data-urlencode`.
-The config endpoint preserves compatibility-oriented model-level business fields. For v1.30.2+
-deployment YAML, move `data_range`, `detection_direction`, `min_dev_from_expected`, and
-`min_rel_dev_from_expected` to `reader.queries.<alias>`, consider `reader.workers: 0` for bounded
-datasource concurrency, and validate the resulting complete configuration before presenting it.
+Use `/api/vmanomaly/config.yaml` for an example configuration and `/api/vmanomaly/example-alert-rule.yaml` for a VMAlert rule. Pass values with `--data-urlencode`. The config endpoint preserves compatibility-oriented model-level business fields. For v1.30.2+ deployment YAML, move `data_range`, `detection_direction`, `min_dev_from_expected`, and `min_rel_dev_from_expected` to `reader.queries.<alias>`, consider `reader.workers: 0` for bounded datasource concurrency, and validate the resulting complete configuration before presenting it.
 
 ## Optional companion skills
 
-- Use `victoriametrics-query` when available to discover metric names, labels, cardinality, or
-  existing alert/rule queries before constructing PromQL/MetricsQL.
+- Use `victoriametrics-query` when available to discover metric names, labels, cardinality, or existing alert/rule queries before constructing PromQL/MetricsQL.
 - Use `victorialogs-query` when the datasource is VictoriaLogs and LogsQL discovery is needed.
 - Use `alertmanager-query` to check active alerts or avoid duplicating existing alerting intent.
 
-These are optional enhancements. Continue through vmanomaly server/proxy endpoints when they are
-not installed.
+These are optional enhancements. Continue through vmanomaly server/proxy endpoints when they are not installed.
 
 ## Reference
 
-Read `references/api-reference.md` for endpoint parameters, response fields, error handling, and
-v1.30 task semantics.
+Read `references/api-reference.md` for endpoint parameters, response fields, error handling, and v1.30 task semantics.

--- a/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/SKILL.md
@@ -46,10 +46,12 @@ curl -q --config "$VM_CURL_CONFIG" -s \
 Interpret compatibility conservatively:
 
 - `global_check.has_state=false`: no persisted state needs migration.
-- `global_check.is_compatible=true`: the checked state can be reused.
+- `global_check.is_compatible=true`: the covered vmanomaly-managed state can be reused.
 - `global_check.drop_everything=true`: report that all persisted state must be dropped; do not perform the drop automatically.
 - `component_assessment.models_to_purge` or `should_purge_reader_data`: report the scoped cleanup.
 - Use `?version_to=X.Y.Z` to assess the stored state against a planned target release.
+
+Compatibility covers vmanomaly-managed state, supported readers, and built-in models, not custom model code, dependencies, or state; before upgrading to v1.30.3+, custom many-to-one models relying on `is_multivariate = True` must declare `topology = ModelTopology.MANY_TO_ONE`.
 
 Only GET compatibility is implemented. Do not invent a POST endpoint for arbitrary provided configs. For configuration syntax, use `/api/v1/config/validate` instead.
 
@@ -179,11 +181,13 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
 ```
 
-Create a task only after validating `model_spec`:
+Create a task only after validating `model_spec`. The v1.30.3 task contract requires an explicit `datasource_url`; reuse the configured datasource URL when appropriate:
 
 ```bash
-jq -n --arg query "$QUERY" '{
+DATASOURCE_URL='<configured-or-explicit-datasource-url>'
+jq -n --arg query "$QUERY" --arg datasource_url "$DATASOURCE_URL" '{
     query:$query,
+    datasource_url:$datasource_url,
     "step":"5m",
     "fit_window":"30d",
     "fit_every":"1000d",

--- a/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
@@ -65,6 +65,8 @@ Important response fields:
 
 No state is a successful result, not an error. The endpoint diagnoses required cleanup but does not perform it. The provided-config POST variant is not implemented in v1.30.
 
+Compatibility covers vmanomaly-managed state, supported readers, and built-in models, not custom model code, dependencies, or state; before upgrading to v1.30.3+, custom many-to-one models relying on `is_multivariate = True` must declare `topology = ModelTopology.MANY_TO_ONE`.
+
 ## Models and configuration
 
 ### `GET /api/v1/models`
@@ -186,7 +188,7 @@ Check available capacity before creating a task. A 429 from task creation means 
 
 Important fields:
 
-- `query`, `step`, `datasource_url` when not resolved from server context
+- `query`, `step`, and required `datasource_url`; reuse the configured datasource URL when appropriate
 - `fit_window`, `fit_every`
 - `start_infer_s`, `end_infer_s`
 - validated `model_spec`

--- a/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
+++ b/plugins/vmanomaly/skills/vmanomaly-query/references/api-reference.md
@@ -1,7 +1,6 @@
 # vmanomaly v1.30 API reference
 
-This reference covers the stable workflows used by the vmanomaly skills. The running OpenAPI
-document and model schemas remain authoritative.
+This reference covers the stable workflows used by the vmanomaly skills. The running OpenAPI document and model schemas remain authoritative.
 
 ## Contents
 
@@ -40,24 +39,19 @@ Base URL: `$VM_ANOMALY_URL`. Include `path_prefix` in this value when configured
 | `/api/vmanomaly/config.yaml` | GET | Generate example configuration |
 | `/api/vmanomaly/example-alert-rule.yaml` | GET | Generate VMAlert rule |
 
-Use JSON request bodies unless an endpoint explicitly accepts YAML or query parameters.
-Times may be Unix seconds; durations use strings such as `5m`, `2w`, or `30d`.
+Use JSON request bodies unless an endpoint explicitly accepts YAML or query parameters. Times may be Unix seconds; durations use strings such as `5m`, `2w`, or `30d`.
 
-`/health` is a point check. Production health should use the documented `/metrics` series together
-with the official vmanomaly self-monitoring dashboard and alert rules, including scheduler-level
-`vmanomaly_scheduler_alive` and `vmanomaly_scheduler_restarts_total` signals.
+`/health` is a point check. Production health should use the documented `/metrics` series together with the official vmanomaly self-monitoring dashboard and alert rules, including scheduler-level `vmanomaly_scheduler_alive` and `vmanomaly_scheduler_restarts_total` signals.
 
 ## Runtime and compatibility
 
 ### `GET /api/v1/server/buildinfo`
 
-Returns the vmanomaly and bundled VMUI versions. Use it to establish runtime capabilities before
-assuming a model or endpoint exists.
+Returns the vmanomaly and bundled VMUI versions. Use it to establish runtime capabilities before assuming a model or endpoint exists.
 
 ### `GET /api/v1/compatibility`
 
-Checks persisted configuration/model/reader state against the current runtime. Optional query
-parameter `version_to=X.Y.Z` checks a planned target instead.
+Checks persisted configuration/model/reader state against the current runtime. Optional query parameter `version_to=X.Y.Z` checks a planned target instead.
 
 Important response fields:
 
@@ -69,47 +63,35 @@ Important response fields:
 - `component_assessment.models_to_purge`
 - `component_assessment.should_purge_reader_data`
 
-No state is a successful result, not an error. The endpoint diagnoses required cleanup but does
-not perform it. The provided-config POST variant is not implemented in v1.30.
+No state is a successful result, not an error. The endpoint diagnoses required cleanup but does not perform it. The provided-config POST variant is not implemented in v1.30.
 
 ## Models and configuration
 
 ### `GET /api/v1/models`
 
-Returns aliases supported by this build. Common v1.30 values include `temporal_envelope`,
-`temporal_envelope_multivariate`, `mad_online`, `zscore_online`, `quantile_online`, `prophet`,
-`holtwinters`, and Isolation Forest variants. Never replace the returned list with a hardcoded one.
+Returns aliases supported by this build. Common v1.30 values include `temporal_envelope`, `temporal_envelope_multivariate`, `mad_online`, `zscore_online`, `quantile_online`, `prophet`, `holtwinters`, and Isolation Forest variants. Never replace the returned list with a hardcoded one.
 
 ### `GET /api/v1/model/schema?model_class=<alias>`
 
-Returns parameter types, bounds, defaults, descriptions, and allowed values. Use the schema as an
-allow-list whenever changing model class. Internal attachment/output fields may not appear in the
-UI-oriented schema.
+Returns parameter types, bounds, defaults, descriptions, and allowed values. Use the schema as an allow-list whenever changing model class. Internal attachment/output fields may not appear in the UI-oriented schema.
 
 ### `POST /api/v1/model/validate`
 
-Accepts one JSON model spec containing `class`. A 201 response is successful. A 422 response
-contains validation details; correct the spec rather than silently dropping user requirements.
+Accepts one JSON model spec containing `class`. A 201 response is successful. A 422 response contains validation details; correct the spec rather than silently dropping user requirements.
 
 ### `POST /api/v1/config/validate`
 
-Validates a full configuration without applying it. Send YAML with `Content-Type:
-application/yaml`. Runtime deployment or hot reload is a separate user-controlled action.
+Validates a full configuration without applying it. Send YAML with `Content-Type: application/yaml`. Runtime deployment or hot reload is a separate user-controlled action.
 
 ### Generated artifacts
 
-`GET /api/vmanomaly/config.yaml` accepts model/query/scheduler parameters and returns YAML.
-`GET /api/vmanomaly/example-alert-rule.yaml` returns a VMAlert rule. Use `--data-urlencode` for
-expressions and durations. The config endpoint preserves the VMUI/model-spec compatibility shape.
-For v1.30.2+ deployment YAML, canonicalize stable business policies under the generated query and
-validate the complete result; generated output still needs human review.
+`GET /api/vmanomaly/config.yaml` accepts model/query/scheduler parameters and returns YAML. `GET /api/vmanomaly/example-alert-rule.yaml` returns a VMAlert rule. Use `--data-urlencode` for expressions and durations. The config endpoint preserves the VMUI/model-spec compatibility shape. For v1.30.2+ deployment YAML, canonicalize stable business policies under the generated query and validate the complete result; generated output still needs human review.
 
 ## Server context and query proxy
 
 ### `GET /api/v1/server/queries`
 
-Returns configured query aliases and expressions. Resolve aliases here before asking the user to
-repeat an already configured query.
+Returns configured query aliases and expressions. Resolve aliases here before asking the user to repeat an already configured query.
 
 ### `GET /api/v1/server/datasource`
 
@@ -124,8 +106,7 @@ Proxies PromQL/MetricsQL or LogsQL through the configured reader path. Typical p
 - `datasource_type` (`vm` or `vlogs`)
 - optional `datasource_url`, `tenant_id`, `pass_auth_headers`
 
-Use the product-specific companion query skill for discovery when installed. A successful empty
-result does not prove that no data exists; first verify the query and label names.
+Use the product-specific companion query skill for discovery when installed. A successful empty result does not prove that no data exists; first verify the query and label names.
 
 ## Time-series characteristics
 
@@ -153,9 +134,7 @@ Key response evidence:
 - `seasonalities.recommended` and per-profile summaries
 - `stats.seriesLimitApplied`, `seriesEstimated`, `seriesLimitMode`
 
-Interpret HOD/hour-of-day as a daily local-hour pattern and DOW/day-of-week as a weekly pattern.
-Limited results are directional samples. Limited reads must fit one query chunk; on a split-chunk
-422, shorten the interval or use a coarser step.
+Interpret HOD/hour-of-day as a daily local-hour pattern and DOW/day-of-week as a weekly pattern. Limited results are directional samples. Limited reads must fit one query chunk; on a split-chunk 422, shorten the interval or use a coarser step.
 
 ## Shared autotune
 
@@ -176,17 +155,12 @@ Useful controls:
 - `optimization_params.n_trials`, `timeout`
 - `optimization_params.exact` for causal online-model evaluation
 - `optimization_params.optimize_complexity` for fitted-state tie-breaking
-- `optimized_business_params` only for legacy model-spec workflows where the user explicitly
-  authorizes business-policy tuning; prefer fixed query policies for v1.30.2+ deployments
-- `frozen_params` for fixed domain/model choices such as direction, holidays, or multivariate
-  `groupby`
+- `optimized_business_params` only for legacy model-spec workflows where the user explicitly authorizes business-policy tuning; prefer fixed query policies for v1.30.2+ deployments
+- `frozen_params` for fixed domain/model choices such as direction, holidays, or multivariate `groupby`
 
-For multivariate models, keep group structure fixed rather than treating it as an optimizer
-dimension. Treat offline-model tuning as a legacy or explicitly requested workflow, not a default
-candidate path.
+For multivariate models, keep group structure fixed rather than treating it as an optimizer dimension. Treat offline-model tuning as a legacy or explicitly requested workflow, not a default candidate path.
 
-Creation returns a task ID immediately. Poll `GET /api/v1/autotune/tasks/{id}` until `done`,
-`error`, or `canceled`.
+Creation returns a task ID immediately. Poll `GET /api/v1/autotune/tasks/{id}` until `done`, `error`, or `canceled`.
 
 On `done`, use:
 
@@ -196,12 +170,9 @@ On `done`, use:
 - `result_data.data.optimization`
 - `result_data.stats`
 
-The result remains a model configuration for validation and ad-hoc/UI tasks. When producing a
-v1.30.2+ deployment, transfer stable `data_range`, `detection_direction`,
-`min_dev_from_expected`, and `min_rel_dev_from_expected` values to each attached query.
+The result remains a model configuration for validation and ad-hoc/UI tasks. When producing a v1.30.2+ deployment, transfer stable `data_range`, `detection_direction`, `min_dev_from_expected`, and `min_rel_dev_from_expected` values to each attached query.
 
-This workflow returns a concrete one-time recommendation. It is different from deploying
-`class: auto`, which retunes during the model fitting lifecycle.
+This workflow returns a concrete one-time recommendation. It is different from deploying `class: auto`, which retunes during the model fitting lifecycle.
 
 There is no v1.30 autotune task-list or limits endpoint. Do not invent them.
 
@@ -209,8 +180,7 @@ There is no v1.30 autotune task-list or limits endpoint. Do not invent them.
 
 ### `GET /api/v1/anomaly_detection/limits`
 
-Check available capacity before creating a task. A 429 from task creation means capacity is
-exhausted; wait or ask before canceling other work.
+Check available capacity before creating a task. A 429 from task creation means capacity is exhausted; wait or ask before canceling other work.
 
 ### `POST /api/v1/anomaly_detection/tasks`
 
@@ -222,17 +192,13 @@ Important fields:
 - validated `model_spec`
 - `exact` and `infer_every` where applicable
 
-For UI/API exploration with an online model, a very large `fit_every` can intentionally preserve
-one causal state through the displayed interval. Production periodic cadence is a separate choice.
+For UI/API exploration with an online model, a very large `fit_every` can intentionally preserve one causal state through the displayed interval. Production periodic cadence is a separate choice.
 
-Task results can contain `y`, `yhat`, bounds, and anomaly score depending on model output. The API
-may constrain output fields for response size; do not copy that response-oriented `provide_series`
-setting into production without an explicit reason.
+Task results can contain `y`, `yhat`, bounds, and anomaly score depending on model output. The API may constrain output fields for response size; do not copy that response-oriented `provide_series` setting into production without an explicit reason.
 
 ### Polling and cancellation
 
-Poll one task every few seconds. Treat `done`, `error`, and `canceled` as terminal. Use DELETE for
-cooperative cancellation only when requested. Never create duplicate tasks to simulate polling.
+Poll one task every few seconds. Treat `done`, `error`, and `canceled` as terminal. Use DELETE for cooperative cancellation only when requested. Never create duplicate tasks to simulate polling.
 
 ## Errors and safe retries
 
@@ -244,5 +210,4 @@ cooperative cancellation only when requested. Never create duplicate tasks to si
 | 429 | task capacity reached | Wait, reduce concurrency, or ask before cancellation |
 | 500 | server/runtime failure | Preserve error details and inspect logs/metrics |
 
-Retry only transient connection/server failures, with a bounded count. Validation failures are not
-transient. Keep tool calls sequential when later calls depend on IDs or results from earlier ones.
+Retry only transient connection/server failures, with a bounded count. Validation failures are not transient. Keep tool calls sequential when later calls depend on IDs or results from earlier ones.

--- a/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
@@ -47,7 +47,7 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/compatibility" | jq .
 ```
 
-Report incompatibility and scoped cleanup; do not execute cleanup. No stored state is healthy. Use `?version_to=X.Y.Z` when reviewing an upgrade. Only GET exists in v1.30.
+Report incompatibility and scoped cleanup; do not execute cleanup. No stored state is healthy. Use `?version_to=X.Y.Z` when reviewing an upgrade. Compatibility covers vmanomaly-managed state, supported readers, and built-in models, not custom model code, dependencies, or state; before upgrading to v1.30.3+, custom many-to-one models relying on `is_multivariate = True` must declare `topology = ModelTopology.MANY_TO_ONE`. Only GET exists in v1.30.
 
 For deployed instances, also verify that self-monitoring metrics are collected and that the official dashboard and alerting rules cover service health, scheduler liveness/restarts, reload failures, model errors/skips, I/O failures, and resource pressure. A successful `/health` response alone is insufficient production evidence.
 
@@ -131,6 +131,7 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/limits" | jq .
 
 MODEL_SPEC_JSON='<validated-model-json>'
+DATASOURCE_URL='<configured-or-explicit-datasource-url>'
 STEP='<configured-step>'
 FIT_WINDOW='<configured-fit-window>'
 FIT_EVERY='<exploratory-fit-cadence>'
@@ -138,6 +139,7 @@ START_INFER_S='<unix-seconds>'
 END_INFER_S='<unix-seconds>'
 jq -n \
   --arg query "$QUERY" \
+  --arg datasource_url "$DATASOURCE_URL" \
   --arg step "$STEP" \
   --arg fit_window "$FIT_WINDOW" \
   --arg fit_every "$FIT_EVERY" \
@@ -145,6 +147,7 @@ jq -n \
   --argjson end_infer_s "$END_INFER_S" \
   --argjson model "$MODEL_SPEC_JSON" '{
     query:$query,
+    datasource_url:$datasource_url,
     step:$step,
     fit_window:$fit_window,
     fit_every:$fit_every,

--- a/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/SKILL.md
@@ -1,19 +1,13 @@
 ---
 name: vmanomaly-review
 description: >
-  Audit an existing VictoriaMetrics vmanomaly configuration against runtime capabilities and
-  real data. Use when reviewing model-data fit, scheduler cadence, persisted-state compatibility,
-  cold start, excessive detections, missing anomalies, output cardinality, or upgrade readiness.
-  Trigger on vmanomaly config review, false-positive investigation, detection quality, model
-  effectiveness, compatibility, and "is my anomaly detection working?" Use vmanomaly-config
-  instead when building a new configuration from scratch.
+  Audit an existing VictoriaMetrics vmanomaly configuration against runtime capabilities and real data. Use when reviewing model-data fit, scheduler cadence, persisted-state compatibility, cold start, excessive detections, missing anomalies, output cardinality, or upgrade readiness. Trigger on vmanomaly config review, false-positive investigation, detection quality, model effectiveness, compatibility, and "is my anomaly detection working?" Use vmanomaly-config instead when building a new configuration from scratch.
 allowed-tools: Bash(curl:*), Bash(jq:*), Read
 ---
 
 # vmanomaly configuration reviewer
 
-Review a running or proposed vmanomaly v1.30+ configuration without mutating it. Separate facts,
-measured evidence, and hypotheses. A static rule may be a better outcome than an ML model.
+Review a running or proposed vmanomaly v1.30+ configuration without mutating it. Separate facts, measured evidence, and hypotheses. A static rule may be a better outcome than an ML model.
 
 Read `references/evaluation-guide.md` before judging detections or model-data fit.
 
@@ -32,8 +26,7 @@ Include any path prefix in the base URL. Never print or create the credential fi
 
 ### 1. Load and summarize the configuration
 
-Read the YAML path supplied by the user, including `configRawYaml` embedded in a Kubernetes
-resource. Summarize:
+Read the YAML path supplied by the user, including `configRawYaml` embedded in a Kubernetes resource. Summarize:
 
 - query aliases and expressions;
 - model aliases/classes, parameters, queries, and schedulers;
@@ -41,8 +34,7 @@ resource. Summarize:
 - datasource type and relevant reader settings;
 - expected reaction time and anomaly intent if known.
 
-Group queries by model so shared parameters and multivariate relationships are visible. Ask for an
-exact missing query; do not invent one.
+Group queries by model so shared parameters and multivariate relationships are visible. Ask for an exact missing query; do not invent one.
 
 ### 2. Run compatibility and capability preflight
 
@@ -55,13 +47,9 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/compatibility" | jq .
 ```
 
-Report incompatibility and scoped cleanup; do not execute cleanup. No stored state is healthy.
-Use `?version_to=X.Y.Z` when reviewing an upgrade. Only GET exists in v1.30.
+Report incompatibility and scoped cleanup; do not execute cleanup. No stored state is healthy. Use `?version_to=X.Y.Z` when reviewing an upgrade. Only GET exists in v1.30.
 
-For deployed instances, also verify that self-monitoring metrics are collected and that the
-official dashboard and alerting rules cover service health, scheduler liveness/restarts, reload
-failures, model errors/skips, I/O failures, and resource pressure. A successful `/health` response
-alone is insufficient production evidence.
+For deployed instances, also verify that self-monitoring metrics are collected and that the official dashboard and alerting rules cover service health, scheduler liveness/restarts, reload failures, model errors/skips, I/O failures, and resource pressure. A successful `/health` response alone is insufficient production evidence.
 
 Discover runtime aliases and fetch the schema for every configured class:
 
@@ -87,8 +75,7 @@ curl -q --config "$VM_CURL_CONFIG" -s \
 Also inspect:
 
 - every query/model/scheduler reference resolves and no important component is orphaned;
-- every model parameter exists in that exact class schema; use full-config validation for reader,
-  scheduler, writer, and top-level fields;
+- every model parameter exists in that exact class schema; use full-config validation for reader, scheduler, writer, and top-level fields;
 - `infer_every` meets the user's reaction-time requirement;
 - fit history covers configured calendar cycles;
 - known data bounds and significance thresholds match query units;
@@ -96,28 +83,20 @@ Also inspect:
 - multivariate `groupby` and channel counts match the intended dependency groups;
 - requested `provide_series` does not create accidental output cardinality;
 - offline models have a suitable refit cadence.
-- for v1.30.2+ deployment YAML, stable `data_range`, `detection_direction`,
-  `min_dev_from_expected`, and `min_rel_dev_from_expected` policies are query-level. Report
-  model-level placement as a deprecated compatible fallback, not a validation failure; explicit
-  query values take precedence.
-- `reader.workers` bounds datasource concurrency, while `settings.n_workers` controls model
-  processes and `settings.native_threads_per_worker` bounds native threads per process.
+- for v1.30.2+ deployment YAML, stable `data_range`, `detection_direction`, `min_dev_from_expected`, and `min_rel_dev_from_expected` policies are query-level. Report model-level placement as a deprecated compatible fallback, not a validation failure; explicit query values take precedence.
+- `reader.workers` bounds datasource concurrency, while `settings.n_workers` controls model processes and `settings.native_threads_per_worker` bounds native threads per process.
 
-Changing class requires reconstructing the spec from the new schema, not deleting errors one by
-one until validation passes.
+Changing class requires reconstructing the spec from the new schema, not deleting errors one by one until validation passes.
 
 ### 4. Re-triage each signal
 
-Flag metrics where static alerting is clearer: hard limits, expiry, binary state, monotonic fill,
-or near-zero failures. Avoid duplicating a precise static alert with a less interpretable model.
+Flag metrics where static alerting is clearer: hard limits, expiry, binary state, monotonic fill, or near-zero failures. Avoid duplicating a precise static alert with a less interpretable model.
 
-Keep ML for natural variance, differing per-series baselines, trend/calendar behavior, persistent
-shifts, or cross-series dependency anomalies.
+Keep ML for natural variance, differing per-series baselines, trend/calendar behavior, persistent shifts, or cross-series dependency anomalies.
 
 ### 5. Profile each exact query
 
-Use the configured query step and timezone, and a history window long enough for claimed
-seasonality:
+Use the configured query step and timezone, and a history window long enough for claimed seasonality:
 
 ```bash
 QUERY='<exact-query>'
@@ -132,20 +111,16 @@ curl -q --config "$VM_CURL_CONFIG" -sG \
   "$VM_ANOMALY_URL/api/v1/timeseries/characteristics" | jq .
 ```
 
-Compare measured trend, profile shape, seasonalities, eligible share, coverage, and series count
-with the configured class and profiles. Limited results are samples. Do not extrapolate exact
-population counts from them.
+Compare measured trend, profile shape, seasonalities, eligible share, coverage, and series count with the configured class and profiles. Limited results are samples. Do not extrapolate exact population counts from them.
 
 Model-fit expectations:
 
-- non-trivial trend/calendar/holiday/shift profile, or uncertainty about a simple stationary
-  baseline: `temporal_envelope` is the preferred first check;
+- non-trivial trend/calendar/holiday/shift profile, or uncertainty about a simple stationary baseline: `temporal_envelope` is the preferred first check;
 - confirmed simple, non-seasonal, heavy-tailed or outlier-contaminated profile: `mad_online`;
 - confirmed simple, stable/light-tailed profile: `zscore_online`;
 - dependency anomaly: `temporal_envelope_multivariate`.
 
-Do not recommend an offline model as a fallback. When reviewing one, treat it as a legacy or
-explicitly requested choice and compare it with the corresponding online model.
+Do not recommend an offline model as a fallback. When reviewing one, treat it as a legacy or explicitly requested choice and compare it with the corresponding online model.
 
 ### 6. Reproduce with a bounded task
 
@@ -185,15 +160,11 @@ curl -q --config "$VM_CURL_CONFIG" -s \
   "$VM_ANOMALY_URL/api/v1/anomaly_detection/tasks/<task_id>" | jq .
 ```
 
-Poll sequentially until `done`, `error`, or `canceled`. Use `exact:true` for causal online-model
-evaluation. Keep query step, timezone, direction, data bounds, and significance thresholds aligned
-with production.
+Poll sequentially until `done`, `error`, or `canceled`. Use `exact:true` for causal online-model evaluation. Keep query step, timezone, direction, data bounds, and significance thresholds aligned with production.
 
-For an exploratory online task, a `fit_every` longer than the inference range preserves a single
-continuous state. This is not automatically the right production cadence.
+For an exploratory online task, a `fit_every` longer than the inference range preserves a single continuous state. This is not automatically the right production cadence.
 
-Do not create duplicates while a task is running. Task creation and config validation are read-only
-with respect to deployment; applying changes is not.
+Do not create duplicates while a task is running. Task creation and config validation are read-only with respect to deployment; applying changes is not.
 
 ### 7. Evaluate evidence correctly
 
@@ -204,8 +175,7 @@ Without labels or user-confirmed events:
 - ask the user which were useful, expected events, or noise;
 - check cold-start, seasonal boundaries, missing data, and regime transitions separately.
 
-With labels, report precision, recall, F1, detection delay, and settled-regime false positives as
-appropriate. Prefer forward/causal validation for online models.
+With labels, report precision, recall, F1, detection delay, and settled-regime false positives as appropriate. Prefer forward/causal validation for online models.
 
 ### 8. Prove proposed fixes
 
@@ -217,12 +187,9 @@ Change the smallest justified set, validate it, and rerun the same bounded inter
 - warmup and adaptation delay;
 - compute/state/output-cardinality impact.
 
-Typical fixes include removing unsupported seasonal profiles, widening/narrowing the ordinary
-envelope, freezing direction/domain thresholds, extending fit history, splitting heterogeneous
-queries, adding multivariate grouping, or choosing a simpler/static detector.
+Typical fixes include removing unsupported seasonal profiles, widening/narrowing the ordinary envelope, freezing direction/domain thresholds, extending fit history, splitting heterogeneous queries, adding multivariate grouping, or choosing a simpler/static detector.
 
-Shared autotune may produce a candidate after model class is chosen. Use `exact:true` for online
-models and apply the returned concrete `modelConfig`; do not silently convert it to `class: auto`.
+Shared autotune may produce a candidate after model class is chosen. Use `exact:true` for online models and apply the returned concrete `modelConfig`; do not silently convert it to `class: auto`.
 
 ### 9. Report
 
@@ -234,25 +201,20 @@ For each query/model provide:
 - minimal proposed change and before/after result;
 - assumptions, confidence, and follow-up observation window.
 
-Separate confirmed faults from hypotheses. A visually unusual point is not automatically an
-anomaly, and an empty query result is not automatically proof of missing data.
+Separate confirmed faults from hypotheses. A visually unusual point is not automatically an anomaly, and an empty query result is not automatically proof of missing data.
 
 ## Optional companion skills
 
-- `victoriametrics-query`: verify PromQL/MetricsQL, self-monitoring ingestion, labels, cardinality,
-  and loaded vmanomaly alert rules.
+- `victoriametrics-query`: verify PromQL/MetricsQL, self-monitoring ingestion, labels, cardinality, and loaded vmanomaly alert rules.
 - `victorialogs-query`: validate LogsQL and correlate log behavior.
-- `alertmanager-query`: inspect active, silenced, or inhibited vmanomaly alerts before declaring
-  service health or duplicated intent.
+- `alertmanager-query`: inspect active, silenced, or inhibited vmanomaly alerts before declaring service health or duplicated intent.
 - `investigating-with-observability`: correlate confirmed detection windows with logs/traces.
 - cardinality-analysis skills: assess excessive series/output fan-out.
 
-These integrations improve evidence but are not prerequisites; continue using vmanomaly proxy and
-server endpoints when they are absent.
+These integrations improve evidence but are not prerequisites; continue using vmanomaly proxy and server endpoints when they are absent.
 
 ## Safety
 
-- Do not apply configs, create persistent rules, purge state, or cancel another user's task without
-  explicit approval.
+- Do not apply configs, create persistent rules, purge state, or cancel another user's task without explicit approval.
 - Bound time windows, series limits, and task concurrency.
 - Preserve exact queries, timestamps, and errors in the report, but redact credentials.

--- a/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
@@ -26,27 +26,19 @@ Do not present levels 2–3 as labeled ground truth.
 ### Deployment readiness
 
 - Online periodic models should restore compatible state from durable on-disk storage.
-- High-churn inputs should use a retention TTL longer than legitimate series absence, with a check
-  interval shorter than both TTL and the smallest `fit_every`.
-- Hot reload should be content-polled, preceded by full-config validation, and covered by reload
-  success metrics.
-- Scatter inference only for many queries and measured synchronized load; match workers to actual
-  CPU limits.
-- Recommend sharding/replication only for measured capacity or availability requirements, and
-  require output deduplication with replicated writers.
-- For high-cardinality outputs, verify writer series/byte batch bounds and metric-prefix cache
-  limits against measured receiver and memory constraints.
-- Prefer the default round-robin sharding unless stable assignment has a concrete state-reuse
-  benefit; if using rendezvous, require the same strategy on every shard and document reassignment
-  risk when the shard count changes.
+- High-churn inputs should use a retention TTL longer than legitimate series absence, with a check interval shorter than both TTL and the smallest `fit_every`.
+- Hot reload should be content-polled, preceded by full-config validation, and covered by reload success metrics.
+- Scatter inference only for many queries and measured synchronized load; match workers to actual CPU limits.
+- Recommend sharding/replication only for measured capacity or availability requirements, and require output deduplication with replicated writers.
+- For high-cardinality outputs, verify writer series/byte batch bounds and metric-prefix cache limits against measured receiver and memory constraints.
+- Prefer the default round-robin sharding unless stable assignment has a concrete state-reuse benefit; if using rendezvous, require the same strategy on every shard and document reassignment risk when the shard count changes.
 
 ### Scheduler timing
 
 - `infer_every` bounds how long a new point may wait for the next scheduled inference.
 - `fit_window` must contain enough cycles for configured seasonality.
 - `fit_every` controls refitting, not the online update cadence.
-- A long `fit_every` is valid for an exploratory exact online task that should preserve one state;
-  it is not a universal production recommendation.
+- A long `fit_every` is valid for an exploratory exact online task that should preserve one state; it is not a universal production recommendation.
 
 Starting history guidance:
 
@@ -56,17 +48,14 @@ Starting history guidance:
 | weekly/DOW | `2w` | `30d` |
 | month-of-year | `24mo` when feasible | `24mo+` |
 
-Partial fit history can initialize online models, but warmup and weaker seasonal estimates should
-be stated. Completely empty fit history requires causal cold-start and delays trusted scores.
+Partial fit history can initialize online models, but warmup and weaker seasonal estimates should be stated. Completely empty fit history requires causal cold-start and delays trusted scores.
 
 ### Cross references
 
 - Every model query and scheduler alias resolves.
-- Every model parameter exists in its exact class schema. Validate reader, scheduler, writer, and
-  other top-level fields and cross-references with full-configuration validation.
+- Every model parameter exists in its exact class schema. Validate reader, scheduler, writer, and other top-level fields and cross-references with full-configuration validation.
 - Multivariate groups contain aligned, semantically related channels.
-- The writer can safely absorb requested output cardinality. Per-channel forecasts or bounds from
-  a joint-score model increase writer cardinality without changing its many-to-one topology.
+- The writer can safely absorb requested output cardinality. Per-channel forecasts or bounds from a joint-score model increase writer cardinality without changing its many-to-one topology.
 
 ## Model-data fit
 
@@ -77,10 +66,7 @@ be stated. Completely empty fit history requires causal cold-start and delays tr
 | trend, several calendar profiles, holidays, or persistent shifts | `temporal_envelope` |
 | normality is a changing relationship between aligned channels | `temporal_envelope_multivariate` |
 
-When the profile is not demonstrably simple and stationary, start the comparison with Temporal
-Envelope rather than treating an offline model as the fallback. Offline models are not first
-candidates for new configurations. Review them only as legacy or explicitly requested choices,
-and compare them with the corresponding online model.
+When the profile is not demonstrably simple and stationary, start the comparison with Temporal Envelope rather than treating an offline model as the fallback. Offline models are not first candidates for new configurations. Review them only as legacy or explicitly requested choices, and compare them with the corresponding online model.
 
 Temporal Envelope profile names are shape hypotheses, not knobs to enable indiscriminately:
 
@@ -113,13 +99,11 @@ Report metrics appropriate to the event:
 - time to stable and settled-regime false-positive rate for adaptation;
 - forecast/boundary error only for models that produce those outputs.
 
-Evaluate online models causally. Batch inference can leak future observations into validation and
-select parameters that underperform in production exact inference.
+Evaluate online models causally. Batch inference can leak future observations into validation and select parameters that underperform in production exact inference.
 
 ### Comparison discipline
 
-Keep query, step, timezone, fit/inference windows, direction, business thresholds, and labels fixed.
-Change one coherent configuration at a time. Record task/model specifications with results.
+Keep query, step, timezone, fit/inference windows, direction, business thresholds, and labels fixed. Change one coherent configuration at a time. Record task/model specifications with results.
 
 ## Common failure patterns
 

--- a/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
+++ b/plugins/vmanomaly/skills/vmanomaly-review/references/evaluation-guide.md
@@ -34,6 +34,11 @@ Do not present levels 2–3 as labeled ground truth.
   CPU limits.
 - Recommend sharding/replication only for measured capacity or availability requirements, and
   require output deduplication with replicated writers.
+- For high-cardinality outputs, verify writer series/byte batch bounds and metric-prefix cache
+  limits against measured receiver and memory constraints.
+- Prefer the default round-robin sharding unless stable assignment has a concrete state-reuse
+  benefit; if using rendezvous, require the same strategy on every shard and document reassignment
+  risk when the shard count changes.
 
 ### Scheduler timing
 
@@ -60,7 +65,8 @@ be stated. Completely empty fit history requires causal cold-start and delays tr
 - Every model parameter exists in its exact class schema. Validate reader, scheduler, writer, and
   other top-level fields and cross-references with full-configuration validation.
 - Multivariate groups contain aligned, semantically related channels.
-- The writer can safely absorb requested output cardinality.
+- The writer can safely absorb requested output cardinality. Per-channel forecasts or bounds from
+  a joint-score model increase writer cardinality without changing its many-to-one topology.
 
 ## Model-data fit
 


### PR DESCRIPTION
## Motivation

Keep reusable vmanomaly configuration and review guidance aligned with the v1.30.3 runtime contract.

## Changes

- Clarify that many-to-one topology describes joint routing and identity, not auxiliary output width.
- Account for per-channel forecasts and bounds when reviewing writer cardinality.
- Add evidence-based guidance for writer batch and metric-prefix cache limits.
- Prefer round-robin by default and recommend rendezvous only when stable assignment has a concrete state-reuse benefit.
- Document consistent shard configuration and shard-count reassignment risk.
- Align all detection-task examples with the required `datasource_url` contract.
- Align compatibility guidance with the built-in/custom-model boundary and explicit many-to-one topology contract.
- Bump the vmanomaly plugin to 1.0.2 and the marketplace catalog to 1.2.2.
- Align Markdown source formatting across all vmanomaly skill files for consistency with the rest of the skills repository.

## Validation

- All vmanomaly skill packages pass the skill validator.
- Markdown diffs and `git diff --check` passed.
- Guidance agrees with the public writer, sharding, custom-model, compatibility, and detection-task documentation.
