### PR TITLE
Add HOL Guard protection for AlertManager mutations

### DIFF
--- a/plugins/query/skills/alertmanager-hol-guard/SKILL.md
+++ b/plugins/query/skills/alertmanager-hol-guard/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: alertmanager-hol-guard
+description: >
+  Protect state-changing AlertManager workflows from a supported local coding-agent harness with HOL Guard.
+  Use before creating or deleting silences when the user wants a local pre-tool approval and evidence boundary.
+  Pair with alertmanager-query for the actual AlertManager API semantics and curl commands.
+allowed-tools: Bash(pipx:*), Bash(hol-guard:*)
+---
+
+# AlertManager + HOL Guard
+
+Use HOL Guard as an additional local agent-runtime boundary before mutation-bearing AlertManager work. Keep `alertmanager-query` authoritative for AlertManager endpoints, payloads, authentication, timestamps, and response handling.
+
+HOL Guard protects the supported local coding-agent harness before tools run. It does not run inside VictoriaMetrics or AlertManager, replace server-side authorization, or validate arbitrary AlertManager API payloads.
+
+## Set up the protected harness
+
+If HOL Guard is missing and runtime protection was requested, prefer an isolated install:
+
+```bash
+pipx install hol-guard
+```
+
+Initialize Guard and detect the active local harness:
+
+```bash
+hol-guard bootstrap
+hol-guard detect --json
+```
+
+Use the exact supported harness identifier returned by `detect`:
+
+```bash
+hol-guard install <harness>
+hol-guard run <harness> --dry-run
+hol-guard run <harness>
+hol-guard status
+```
+
+For Hermes, use its dedicated bootstrap flow:
+
+```bash
+hol-guard hermes bootstrap
+```
+
+Do not claim the session is protected unless current Guard status or doctor output proves it. Run the AlertManager workflow from the protected harness launched by `hol-guard run`.
+
+## Route AlertManager work to the maintained skill
+
+Once the protected harness is active, use `alertmanager-query` for the actual API workflow. That skill remains the source of truth for:
+
+- listing alerts and silences,
+- creating silences,
+- retrieving silence state,
+- expiring/deleting silences,
+- authentication through `VM_CURL_CONFIG`, and
+- AlertManager-specific endpoint and payload details.
+
+If `alertmanager-query` is unavailable, stop and install or load the maintained query plugin instead of reconstructing AlertManager mutation commands from memory.
+
+## Require Guard before state changes
+
+Use the protected harness before agent-driven AlertManager mutations, especially creating a silence or expiring/deleting one. Preserve the confirmation and safety behavior documented by `alertmanager-query`.
+
+If Guard denies, requests review, errors, times out, or cannot prove the protected harness is active, stop before the AlertManager mutation. Do not retry the same write from an unprotected session.
+
+Review local Guard state with:
+
+```bash
+hol-guard approvals
+hol-guard approvals open
+hol-guard receipts
+```
+
+Read-only alert and silence queries remain governed by `alertmanager-query`; do not create a mutation merely to prove Guard is working.
+
+## Evidence and troubleshooting
+
+```bash
+hol-guard doctor
+hol-guard doctor <harness> --json
+hol-guard receipts
+hol-guard inventory
+hol-guard events
+```
+
+Report separately:
+
+1. what AlertManager mutation the maintained skill prepared,
+2. what Guard proved, denied, or routed to review at the local harness boundary,
+3. the AlertManager response after an approved protected mutation, and
+4. any remaining operator action.
+
+Canonical HOL Guard setup: https://github.com/hashgraph-online/hol-guard-plugin/tree/main/skills/hol-guard


### PR DESCRIPTION
## Summary

Adds `alertmanager-hol-guard` to the existing query plugin as an optional local runtime-safety skill for state-changing AlertManager workflows.

The skill directly installs and invokes HOL Guard on a supported local coding-agent harness before creating or expiring/deleting AlertManager silences, while keeping the existing `alertmanager-query` skill authoritative for endpoints, payloads, authentication, timestamps, and response handling.

## Scope

- one new repository-native skill under `plugins/query/skills/alertmanager-hol-guard/`
- uses the current HOL Guard setup flow: `bootstrap`, `detect`, `install`, protected `run`, status/doctor, approvals, and receipts
- fail-closed guidance for deny/review/error/timeout/unavailable Guard states
- no duplicated AlertManager curl command tables
- no claim that HOL Guard runs inside VictoriaMetrics/AlertManager or replaces server-side authorization
- no write is introduced merely to test Guard

## Repository fit / validation

- the repository's query plugin already contains the mutation-bearing `alertmanager-query` skill, including create/delete silence workflows
- exact upstream issue/PR search for HOL Guard was clean immediately before opening
- current repository root exposes no additional contribution, CLA/DCO, or human-attestation policy beyond the public fork/PR surface
- HOL Guard commands were checked against its maintained canonical skill/source
- no live AlertManager mutation was executed or claimed for this instruction-only contribution

Affiliation: I maintain HOL Guard / Hashgraph Online. AI assistance was used to prepare the focused skill; the final scope was checked against the current VictoriaMetrics skill structure and AlertManager workflow.