### PR TITLE
docs(vmanomaly): guide named-query Copilot tuning and compact context

### DIFF
--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -212,18 +212,24 @@ Provide:
 
 Generated `/api/vmanomaly/config.yaml` and `/api/vmanomaly/example-alert-rule.yaml` output is a starting point, not proof of correctness. The config endpoint preserves the VMUI/model-spec compatibility shape; before presenting v1.30.2+ deployment YAML, move the four stable business policies to `reader.queries.<alias>`, add `reader.workers` when appropriate, and validate the final configuration.
 
-## Safety
-
-- API validation and tasks do not deploy or hot-reload configuration.
-- Obtain approval before applying configs, creating persistent alert rules, or deleting state.
-- Bound samples, time ranges, series limits, trial counts, and concurrent tasks.
-- Never infer that empty data means the metric does not exist until the query and labels are checked.
-
-
-### Efficient Copilot context
+## Efficient Copilot context
 
 Reuse already available schemas, profiles and completed task results. Use focused documentation search with a small explicit top-k (usually 3–5); results may be excerpts. Check their source URI, offsets and truncation marker, then use `vmanomaly_read_doc_section` to retrieve missing context before relying on it. Do not treat excerpt omission as evidence that a parameter or limitation does not exist. Avoid repeating broad searches and full documentation in conversation history.
 
 Show each proposed configuration once through its approval card; reserve standalone YAML for explicit export requests. Keep explanations short. Never reduce context by dropping query aliases, expressions, disabled rows, business-policy inheritance, validation constraints, or pending approval data. Named-query UI application does not imply shared named-query autotune support; inspect the actual tool schema.
 
 The backend may compact duplicate completed tool results and enforce a local context budget independently of the provider. On a budget refusal, keep the current UI state and explain how to resume with a narrower request or a fresh conversation; do not claim an unapplied suggestion succeeded. Token ceilings are maximum output allowances, not targets. Usage counters and byte comparisons are useful for measurement but do not establish exact provider billing savings.
+
+
+## Joint autotune of named queries
+
+When the connected autotune schema exposes `queries`, send one map of active aliases to exact expressions and explicit business policies, omitting the legacy `query` field. Preserve null/omitted inheritance versus explicit zero, both and unbounded overrides. Tune the actual multivariate model class in one task and put model grouping in `frozen_params.groupby`. Each candidate is evaluated across independently fitted aligned groups, producing one shared configuration. Never merge separately tuned univariate configurations and describe the result as jointly tuned multivariate detection. The per-expression sample cap may need increasing to include matching groups from every query; incomplete groups fail explicitly.
+
+For older servers without this contract, explain the limitation rather than silently discarding queries or their policies. Keep `anomaly_percentage` described as a tuning target, not a guaranteed anomaly or false-positive upper bound. Apply the resulting model suggestion with the existing named queries and policy state; query-local policies must not be promoted to shared defaults accidentally.
+
+## Safety
+
+- API validation and tasks do not deploy or hot-reload configuration.
+- Obtain approval before applying configs, creating persistent alert rules, or deleting state.
+- Bound samples, time ranges, series limits, trial counts, and concurrent tasks.
+- Never infer that empty data means the metric does not exist until the query and labels are checked.

--- a/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
+++ b/plugins/vmanomaly/skills/vmanomaly-config/SKILL.md
@@ -117,7 +117,7 @@ Default hierarchy:
 
 - Fix `detection_direction` when business intent is known, and map insignificant absolute/relative deviations to `min_dev_from_expected` and `min_rel_dev_from_expected`.
 - In v1.30.2+ deployable YAML, place `data_range`, `detection_direction`, `min_dev_from_expected`, and `min_rel_dev_from_expected` under `reader.queries.<alias>`. Query values are authoritative across attached models; model-level values remain compatible local fallbacks but are deprecated.
-- For VMUI or an ad-hoc detection task, keep these fields in `model_spec`: the UI suggestion/query contract does not expose per-query business-policy fields. The backend maps `data_range` to the temporary query and resolves the other fields as model-local compatibility values.
+- For VMUI, inspect the connected suggestion contract. When `suggest_query_config` exposes `queries` and `expected_revision`, apply complete named query rows with their aliases, enabled states and per-query policies, copying the current revision and preserving untouched rows. Null/omitted policies inherit; explicit zero, both and unbounded values override. Older single-query contracts cannot apply a named query set; do not silently drop its policies. Keep model-level defaults separate.
 - Set model-level `clip_predictions` only when forecast and interval outputs should be clipped to that domain.
 - Use `min_n_samples_seen` to suppress scores during cold-start; express its duration as samples multiplied by query step.
 - For stable MAD, Z-score, or online-quantile data, consider `history_strength > 1` instead of many extra fit cycles; keep enough history to cover every required seasonal phase.
@@ -218,3 +218,12 @@ Generated `/api/vmanomaly/config.yaml` and `/api/vmanomaly/example-alert-rule.ya
 - Obtain approval before applying configs, creating persistent alert rules, or deleting state.
 - Bound samples, time ranges, series limits, trial counts, and concurrent tasks.
 - Never infer that empty data means the metric does not exist until the query and labels are checked.
+
+
+### Efficient Copilot context
+
+Reuse already available schemas, profiles and completed task results. Use focused documentation search with a small explicit top-k (usually 3–5); results may be excerpts. Check their source URI, offsets and truncation marker, then use `vmanomaly_read_doc_section` to retrieve missing context before relying on it. Do not treat excerpt omission as evidence that a parameter or limitation does not exist. Avoid repeating broad searches and full documentation in conversation history.
+
+Show each proposed configuration once through its approval card; reserve standalone YAML for explicit export requests. Keep explanations short. Never reduce context by dropping query aliases, expressions, disabled rows, business-policy inheritance, validation constraints, or pending approval data. Named-query UI application does not imply shared named-query autotune support; inspect the actual tool schema.
+
+The backend may compact duplicate completed tool results and enforce a local context budget independently of the provider. On a budget refusal, keep the current UI state and explain how to resume with a narrower request or a fresh conversation; do not claim an unapplied suggestion succeeded. Token ceilings are maximum output allowances, not targets. Usage counters and byte comparisons are useful for measurement but do not establish exact provider billing savings.


### PR DESCRIPTION
Update the vmanomaly configuration skill for named-query UI suggestions and shared multivariate autotune. Preserve aliases, per-query business policies and inheritance, use revision checks when applying query sets, and keep grouping in `frozen_params.groupby`.

Inspect connected tool capabilities for compatibility, tune the multivariate class in one shared study, and avoid treating independently tuned univariate configurations as joint tuning. Add guidance for focused documentation retrieval and continuation, reusing evidence, avoiding duplicate configuration output, and recovering from context-budget refusals without losing approval or query state.

Validation: documentation reviewed against the corresponding tool contracts and grouped named-query integration checks.

Companion tools: [MCP #20](https://github.com/VictoriaMetrics/mcp-vmanomaly/pull/20).
