### PR TITLE
fix(victorialogs): document the missing end arg for stats_query

### DIFF
--- a/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
@@ -130,12 +130,14 @@ LogsQL is space-separated (AND by default). Pipes use `|`.
 
 ### Instant (single point in time)
 
-Use `stats_query` with `time`. The query MUST contain a `| stats` pipe.
+Use `stats_query` with `start` and `end`. The query MUST contain a `| stats` pipe.
+Pass both bounds. `time` is only the evaluation timestamp and does not bound the range,
+so omitting `end` aggregates from `start` to now.
 
 ```bash
 curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
   --data-urlencode 'query={namespace="<NAMESPACE>"} | stats by (level) count() as total' \
-  "$VM_LOGS_URL/select/logsql/stats_query?time=<RFC3339>" | jq .
+  "$VM_LOGS_URL/select/logsql/stats_query?start=<RFC3339>&end=<RFC3339>" | jq .
 ```
 
 ### Range (over a time window)

--- a/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
+++ b/plugins/diagnostics/skills/investigating-with-observability/agents/logs-discovery.md
@@ -128,7 +128,7 @@ LogsQL is space-separated (AND by default). Pipes use `|`.
 
 ## Stats Queries
 
-### Instant (single point in time)
+### Instant (one value per group)
 
 Use `stats_query` with `start` and `end`. The query MUST contain a `| stats` pipe.
 Pass both bounds. `time` is only the evaluation timestamp and does not bound the range,
@@ -150,7 +150,7 @@ curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
   "$VM_LOGS_URL/select/logsql/stats_query_range?start=<RFC3339>&end=<RFC3339>&step=1h" | jq .
 ```
 
-**Do NOT confuse these two:** `stats_query` uses `time` (instant), `stats_query_range` uses `start`/`end`/`step` (range).
+**Do NOT confuse these two:** `stats_query` returns one value per group, `stats_query_range` returns a series per `step`. Both bound the range with `start`/`end`.
 
 ---
 

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -66,7 +66,7 @@ Response: JSON Lines (one JSON object per line). Pipe through `jq -s .` to colle
 ### Stats Query (Instant)
 
 ```bash
-# Count errors by level at a point in time
+# Count errors by level over a 9-hour range
 curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
   --data-urlencode 'query={namespace="myapp"} | stats by (level) count() as total' \
   "$VM_LOGS_URL/select/logsql/stats_query?start=2026-03-07T00:00:00Z&end=2026-03-07T09:00:00Z" | jq .

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -36,7 +36,8 @@ When `VM_CURL_CONFIG` is unset, curl reads `/dev/null` and sends no auth header.
 ## Critical Rules
 
 - ALWAYS pass `start` on ALL VictoriaLogs endpoints — omitting it scans ALL stored data (extremely expensive). Not technically required by the API, but omitting it is almost never what you want.
-- `stats_query` uses `time` (ALWAYS pass it explicitly; do not rely on a default), `stats_query_range` uses `start`/`end`/`step`
+- `stats_query` bounds its aggregation range with `start` AND `end`. `time` is only the Prometheus evaluation timestamp and does NOT bound the range. Passing `start` without `end` aggregates from `start` to now, so an earlier window becomes a superset of a later one and period-over-period comparisons invert silently
+- `stats_query_range` uses `start`/`end`/`step`
 - `step` is required for `hits` endpoint
 - `/select/logsql/query` returns JSON Lines (one JSON object per line), NOT a JSON array
 - LogsQL queries with special characters MUST be URL-encoded (use `--data-urlencode` for POST)
@@ -68,10 +69,24 @@ Response: JSON Lines (one JSON object per line). Pipe through `jq -s .` to colle
 # Count errors by level at a point in time
 curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
   --data-urlencode 'query={namespace="myapp"} | stats by (level) count() as total' \
-  "$VM_LOGS_URL/select/logsql/stats_query?time=2026-03-07T09:00:00Z" | jq .
+  "$VM_LOGS_URL/select/logsql/stats_query?start=2026-03-07T00:00:00Z&end=2026-03-07T09:00:00Z" | jq .
 ```
 
-Parameters: `query` (required, must contain `| stats` pipe), `time` (required, RFC3339), `start` (optional, alternative to `time`).
+Parameters: `query` (required, must contain `| stats` pipe), `start` and `end` (RFC3339, bound the aggregation range — pass both), `time` (RFC3339, evaluation timestamp only).
+
+Comparing two periods needs an explicit `end` on each call. Without it both ranges run to now, the earlier range contains the later one, and the trend inverts:
+
+```bash
+# previous week
+curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
+  --data-urlencode 'query={namespace="myapp"} | stats count() as total' \
+  "$VM_LOGS_URL/select/logsql/stats_query?start=2026-03-01T00:00:00Z&end=2026-03-08T00:00:00Z" | jq .
+
+# latest week
+curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
+  --data-urlencode 'query={namespace="myapp"} | stats count() as total' \
+  "$VM_LOGS_URL/select/logsql/stats_query?start=2026-03-08T00:00:00Z&end=2026-03-15T00:00:00Z" | jq .
+```
 
 Response: Prometheus-compatible JSON format.
 
@@ -271,5 +286,5 @@ echo "VM_CURL_CONFIG: ${VM_CURL_CONFIG:-(unset - no auth)}"
 - ALL endpoints accept both GET and POST with `application/x-www-form-urlencoded`
 - `field` parameter is required for `field_values` and `stream_field_values` endpoints
 - `facets` is the best single-call discovery tool — returns all field distributions at once
-- Do NOT confuse `stats_query` (instant, uses `time`) with `stats_query_range` (range, uses `start`/`end`/`step`)
+- Do NOT confuse `stats_query` (instant, one value per group) with `stats_query_range` (a series per `step`). Both bound the range with `start`/`end`
 - For full endpoint details, parameters, and response formats, see `references/api-reference.md`

--- a/plugins/query/skills/victorialogs-query/SKILL.md
+++ b/plugins/query/skills/victorialogs-query/SKILL.md
@@ -36,7 +36,7 @@ When `VM_CURL_CONFIG` is unset, curl reads `/dev/null` and sends no auth header.
 ## Critical Rules
 
 - ALWAYS pass `start` on ALL VictoriaLogs endpoints — omitting it scans ALL stored data (extremely expensive). Not technically required by the API, but omitting it is almost never what you want.
-- `stats_query` bounds its aggregation range with `start` AND `end`. `time` is only the Prometheus evaluation timestamp and does NOT bound the range. Passing `start` without `end` aggregates from `start` to now, so an earlier window becomes a superset of a later one and period-over-period comparisons invert silently
+- `stats_query` bounds its aggregation range with `start` AND `end`. `time` is only the Prometheus evaluation timestamp and does NOT bound the range. Passing `start` without `end` aggregates from `start` to now
 - `stats_query_range` uses `start`/`end`/`step`
 - `step` is required for `hits` endpoint
 - `/select/logsql/query` returns JSON Lines (one JSON object per line), NOT a JSON array

--- a/plugins/query/skills/victorialogs-query/references/api-reference.md
+++ b/plugins/query/skills/victorialogs-query/references/api-reference.md
@@ -49,8 +49,9 @@ Evaluate a LogsQL stats query at a single point in time. Query MUST contain a `|
 | Parameter | Required | Type | Default | Description |
 |-----------|----------|------|---------|-------------|
 | `query` | Yes | string | - | LogsQL query with `| stats` pipe |
-| `time` | Yes* | RFC3339 | - | Evaluation timestamp. *Required despite docs marking optional. |
-| `start` | No | RFC3339 | - | Alternative to `time` — start of aggregation window |
+| `start` | Yes* | RFC3339 | min stored | Start of the aggregation range |
+| `end` | Yes* | RFC3339 | now | End of the aggregation range. *Omit it and the range runs to now, which silently inverts period-over-period comparisons. |
+| `time` | No | RFC3339 | now | Prometheus evaluation timestamp. Does NOT bound the range. |
 
 Response (Prometheus-compatible JSON):
 
@@ -78,7 +79,7 @@ Example:
 ```bash
 curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
   --data-urlencode 'query={namespace="myapp"} | stats by (level) count() as total' \
-  "$VM_LOGS_URL/select/logsql/stats_query?time=2026-03-07T09:00:00Z" | jq .
+  "$VM_LOGS_URL/select/logsql/stats_query?start=2026-03-07T00:00:00Z&end=2026-03-07T09:00:00Z" | jq .
 ```
 
 ### GET/POST /select/logsql/stats_query_range — Range Stats

--- a/plugins/query/skills/victorialogs-query/references/api-reference.md
+++ b/plugins/query/skills/victorialogs-query/references/api-reference.md
@@ -44,14 +44,16 @@ curl -q --config "${VM_CURL_CONFIG:-/dev/null}" -s \
 
 ### GET/POST /select/logsql/stats_query — Instant Stats
 
-Evaluate a LogsQL stats query at a single point in time. Query MUST contain a `| stats` pipe.
+Aggregate a LogsQL stats query over the `start`..`end` range and return one value per group. Query MUST contain a `| stats` pipe.
 
 | Parameter | Required | Type | Default | Description |
 |-----------|----------|------|---------|-------------|
 | `query` | Yes | string | - | LogsQL query with `| stats` pipe |
 | `start` | Yes* | RFC3339 | min stored | Start of the aggregation range |
-| `end` | Yes* | RFC3339 | now | End of the aggregation range. *Omit it and the range runs to now, which silently inverts period-over-period comparisons. |
+| `end` | Yes* | RFC3339 | now | End of the aggregation range |
 | `time` | No | RFC3339 | now | Prometheus evaluation timestamp. Does NOT bound the range. |
+
+*Pass both bounds. Each falls back to its default on its own, so `start` without `end` aggregates from `start` to now and silently inverts period-over-period comparisons.
 
 Response (Prometheus-compatible JSON):
 


### PR DESCRIPTION
#### Why?

The docs gave `stats_query` a `time` arg and listed `start` as an "alternative to `time`". `end` was never mentioned. But `time` is only the Prometheus evaluation timestamp — the range comes from `start` and `end`:

> The time range for the calculated stats can be additionally limited via optional start and end query args.

So the documented call aggregates from `start` to now. Compare two periods and both ranges run to now, the earlier one contains the later one, and a rising metric reads as falling. The request succeeds, so nothing signals the mistake.

#### How?

Documented `start` and `end` as the range bounds, demoted `time` to the evaluation timestamp, and added a two-period example. Same fix in the reference file and in `logs-discovery.md`, which repeated the guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
